### PR TITLE
Add support for in placement new operator w/o new lib

### DIFF
--- a/cpp/neuralnet.hpp
+++ b/cpp/neuralnet.hpp
@@ -1201,6 +1201,12 @@ namespace tinymind {
             this->mWeight = value;
         }
 
+#if !(defined(_LIB_NEW) || defined(_NEW))
+        void * operator new(size_t, void *p)
+        {
+            return p;
+        }
+#endif
     protected:
         ValueType mWeight;
     };
@@ -1322,6 +1328,13 @@ namespace tinymind {
         {
             this->mOutputValue = value;
         }
+
+#if !(defined(_LIB_NEW) || defined(_NEW))
+        void * operator new(size_t, void *p)
+        {
+            return p;
+        }
+#endif
 
     protected: // Don't instantiate class. Only for use by child classses
         Neuron()
@@ -1960,6 +1973,13 @@ namespace tinymind {
             NeuronType* pNeuron = reinterpret_cast<NeuronType*>(&this->mNeuronsBuffer[bufferIndex]);
             pNeuron->setWeightForConnection(connection, weight);
         }
+
+#if !(defined(_LIB_NEW) || defined(_NEW))
+        void * operator new(size_t, void *p)
+        {
+            return p;
+        }
+#endif
     protected:
         Layer()
         {

--- a/cpp/qformat.hpp
+++ b/cpp/qformat.hpp
@@ -400,6 +400,13 @@ namespace tinymind {
             return (mValue.getValue() != value);
         }
 
+#if !(defined(_LIB_NEW) || defined(_NEW))
+        void * operator new(size_t, void *p)
+        {
+            return p;
+        }
+#endif
+
 #if TINYMIND_ENABLE_OSTREAMS
         friend std::ostream& operator<<(std::ostream& os, const QValue& value)
         {

--- a/cpp/qlearn.hpp
+++ b/cpp/qlearn.hpp
@@ -338,7 +338,7 @@ namespace tinymind {
         typedef typename EnvironmentType::EnvironmentStateType StateType;
         typedef typename EnvironmentType::EnvironmentActionType ActionType;
         typedef typename EnvironmentType::EnvironmentValueType ValueType;
-
+        
         static ActionType selectBestActionForState(const StateType state, ActionType const* const actions, const size_t numberOfValidActions, const QLearnerQValuePolicy& qValuePolicy)
         {
             ActionType bestAction;
@@ -526,6 +526,13 @@ namespace tinymind {
                 }
             }
         }
+
+#if !(defined(_LIB_NEW) || defined(_NEW))
+        void * operator new(size_t, void *p)
+        {
+            return p;
+        }
+#endif
     private:
         void copyNetworkWeights()
         {
@@ -652,6 +659,13 @@ namespace tinymind {
 
             this->mState = experience.newState;
         }
+
+#if !(defined(_LIB_NEW) || defined(_NEW))
+        void * operator new(size_t, void *p)
+        {
+            return p;
+        }
+#endif
     private:
         // Private methods
         ValueType calculateFutureQValue(const StateType state)

--- a/examples/maze/Makefile
+++ b/examples/maze/Makefile
@@ -11,6 +11,12 @@ debug :
 #	Build the example with default build flags
 	g++ -g -Wall -o ./output/maze maze.cpp mazelearner.cpp -I../../cpp
 
+nonewlib :
+#	Make an output dir to hold the executable
+	mkdir -p ./output
+#	Build the example with default build flags and do not include the new library
+	g++ -O3 -Wall -o ./output/maze maze.cpp mazelearner.cpp -I../../cpp -DTINYMIND_DISABLE_NEW_LIB=1
+
 # Remove all object files
 clean:
 	rm -f ./output/*

--- a/examples/maze/maze.cpp
+++ b/examples/maze/maze.cpp
@@ -57,6 +57,13 @@ The paths out of the maze:
 
 #include "mazelearner.h"
 
+#if !(defined(_LIB_NEW) || defined(_NEW))
+void * operator new(size_t, void *p)
+{
+    return p;
+}
+#endif
+
 extern QLearnerType qLearner;
 
 int main(const int argc, char *argv[])

--- a/examples/maze/mazelearner.h
+++ b/examples/maze/mazelearner.h
@@ -25,7 +25,9 @@
 #include <cstdint>
 #include <cstdlib>
 #include <ctime>
+#if !(TINYMIND_DISBLE_NEW_LIB)
 #include <new>
+#endif
 
 #include "qformat.hpp"
 #include "qlearn.hpp"


### PR DESCRIPTION
llvm/libcxx/new defines _LIB_NEW
libstdc++ new defines _NEW

If neither of these are present, the embedded system may not be including these standard libraries, so we will need to define them here. This will enable the placement new operations.

Added is a build flag for an example test to build and verify w/o the <new> lib