### PR TITLE
Add FFT layer and sin/cos lookup tables

### DIFF
--- a/apps/activation/activationTableGenerator.cpp
+++ b/apps/activation/activationTableGenerator.cpp
@@ -58,6 +58,8 @@ typedef enum
     sigmoidActivation,
     expActivation,
     logActivation,
+    sinActivation,
+    cosActivation,
     endActivation
 } activation_e;
 
@@ -68,16 +70,16 @@ typedef struct
 } copyrightSpan_t;
 
 static std::string folderPathString;
-static char const* const activationTags[] = {"TINYMIND_USE_TANH_", "TINYMIND_USE_SIGMOID_", "TINYMIND_USE_EXP_", "TINYMIND_USE_LOG_"};
+static char const* const activationTags[] = {"TINYMIND_USE_TANH_", "TINYMIND_USE_SIGMOID_", "TINYMIND_USE_EXP_", "TINYMIND_USE_LOG_", "TINYMIND_USE_SIN_", "TINYMIND_USE_COS_"};
 static const uint8_t tables[] = {8, 16, 32, 64, 128};
 
 using namespace std;
 
 static const string lutFileName = "lookupTables.cpp";
-static const string selectorPath[] = {"tanh.hpp", "sigmoid.hpp", "exp.hpp", "log.hpp"};
-static const string valuesPathPrefix[] = {"tanhValues", "sigmoidValues", "expValues", "logValues"};
-static const string structPrefixes[] = {"Tanh", "Sigmoid", "Exp", "Log"};
-static const string includePrefix[] = {"tanh", "sigmoid", "exp", "log"};
+static const string selectorPath[] = {"tanh.hpp", "sigmoid.hpp", "exp.hpp", "log.hpp", "sin.hpp", "cos.hpp"};
+static const string valuesPathPrefix[] = {"tanhValues", "sigmoidValues", "expValues", "logValues", "sinValues", "cosValues"};
+static const string structPrefixes[] = {"Tanh", "Sigmoid", "Exp", "Log", "Sin", "Cos"};
+static const string includePrefix[] = {"tanh", "sigmoid", "exp", "log", "sin", "cos"};
 
 static_assert((sizeof(selectorPath) / sizeof(string)) == endActivation, "Invalid selector file path array size.");
 static_assert((sizeof(valuesPathPrefix) / sizeof(string)) == endActivation, "Invalid path prefix array size.");
@@ -281,6 +283,14 @@ static void writeLutValues(string path, const size_t totalBits, uint64_t fixedBi
             {
                 activate = 0.0;
             }
+        }
+        else if (sinActivation == activationType)
+        {
+            activate = std::sin(value);
+        }
+        else if (cosActivation == activationType)
+        {
+            activate = std::cos(value);
         }
         else
         {
@@ -500,6 +510,8 @@ int main(const int argc, char *argv[])
     generateHeader(tanhActivation);
     generateHeader(expActivation);
     generateHeader(logActivation);
+    generateHeader(sinActivation);
+    generateHeader(cosActivation);
 
     fs::path lutPath(folderPath);
     lutPath /= lutFileName;

--- a/apps/activation/activationTableGenerator.cpp
+++ b/apps/activation/activationTableGenerator.cpp
@@ -94,15 +94,18 @@ static double sigmoid(const double x)
     return result;
 }
 
-static void writeFileCopyrightAndLicense(const string& path)
+static bool activationRequiresIntelCopyright(const activation_e activationType)
+{
+    return (activationType != sinActivation && activationType != cosActivation);
+}
+
+static void writeFileCopyrightAndLicense(const string& path, const bool includeIntelCopyright = true)
 {
     ifstream myInFile("../my_copyright.txt");
-    ifstream intelInFile("../intel_copyright.txt");
     ofstream outFile(path);
     char buffer[1024];
 
     assert(myInFile.is_open());
-    assert(intelInFile.is_open());
 
     while(!myInFile.eof())
     {
@@ -111,17 +114,25 @@ static void writeFileCopyrightAndLicense(const string& path)
         outFile << std::endl;
     }
 
-    while(!intelInFile.eof())
+    if (includeIntelCopyright)
     {
-        intelInFile.getline(buffer, 1024);
-        outFile.write(buffer, strlen(buffer));
-        outFile << std::endl;
+        ifstream intelInFile("../intel_copyright.txt");
+        assert(intelInFile.is_open());
+
+        while(!intelInFile.eof())
+        {
+            intelInFile.getline(buffer, 1024);
+            outFile.write(buffer, strlen(buffer));
+            outFile << std::endl;
+        }
+
+        intelInFile.close();
     }
+
     outFile << std::endl;
 
     outFile.flush();
     outFile.close();
-    intelInFile.close();
 }
 
 static void writeNamespaceBegin(const string& path)
@@ -146,9 +157,9 @@ static void writeActivationFileHeader(const string& path)
     outFile << "#pragma once" << endl << endl;
 }
 
-static void writeFileHeader(const string& path)
+static void writeFileHeader(const string& path, const bool includeIntelCopyright = true)
 {
-    writeFileCopyrightAndLicense(path);
+    writeFileCopyrightAndLicense(path, includeIntelCopyright);
 
     ofstream outFile(path, ofstream::app);
     outFile << "#pragma once" << endl << endl;
@@ -406,6 +417,7 @@ static void generateLut(const string& path, const activation_e activationType)
 static void generateHeader(const activation_e activationType)
 {
     fs::path selectorFilePath(folderPathString);
+    const bool includeIntelCopyright = activationRequiresIntelCopyright(activationType);
 
     selectorFilePath /= selectorPath[activationType];
 
@@ -414,12 +426,12 @@ static void generateHeader(const activation_e activationType)
         fs::path filePath(folderPathString);
         const uint8_t totalBits = tables[index];
         string fileName = valuesPathPrefix[activationType] + to_string(totalBits);
-        
+
         fileName.append("Bit.hpp");
 
         filePath /= fileName;
 
-        writeFileHeader(filePath.string());
+        writeFileHeader(filePath.string(), includeIntelCopyright);
 
         writeNamespaceBegin(filePath.string());
 
@@ -432,7 +444,7 @@ static void generateHeader(const activation_e activationType)
     }
 
 
-    writeFileHeader(selectorFilePath.string());
+    writeFileHeader(selectorFilePath.string(), includeIntelCopyright);
 
     for(uint8_t index = 0;index < ((sizeof(tables) / sizeof(tables[0])));++index)
     {

--- a/cpp/activation.hpp
+++ b/cpp/activation.hpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023 Dan McLeran
+* Copyright (c) 2026 Dan McLeran
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/cpp/cos.hpp
+++ b/cpp/cos.hpp
@@ -1,0 +1,2009 @@
+/**
+* Copyright (c) 2026 Dan McLeran
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+/**
+* Copyright (c) 2020 Intel Corporation
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#pragma once
+
+#include "activation.hpp"
+
+#include "cosValues8Bit.hpp"
+#include "cosValues16Bit.hpp"
+#include "cosValues32Bit.hpp"
+#include "cosValues64Bit.hpp"
+#include "cosValues128Bit.hpp"
+
+namespace tinymind {
+    template<unsigned FixedBits, unsigned FracBits, bool IsSigned>
+    struct CosTableValueSize
+    {
+    };
+
+    #if TINYMIND_USE_COS_1_7
+    template<>
+    struct CosTableValueSize<1, 7, true>
+    {
+        typedef CosValuesTableQ1_7 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_1_7
+
+    #if TINYMIND_USE_COS_2_6
+    template<>
+    struct CosTableValueSize<2, 6, true>
+    {
+        typedef CosValuesTableQ2_6 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_2_6
+
+    #if TINYMIND_USE_COS_3_5
+    template<>
+    struct CosTableValueSize<3, 5, true>
+    {
+        typedef CosValuesTableQ3_5 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_3_5
+
+    #if TINYMIND_USE_COS_4_4
+    template<>
+    struct CosTableValueSize<4, 4, true>
+    {
+        typedef CosValuesTableQ4_4 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_4_4
+
+    #if TINYMIND_USE_COS_5_3
+    template<>
+    struct CosTableValueSize<5, 3, true>
+    {
+        typedef CosValuesTableQ5_3 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_5_3
+
+    #if TINYMIND_USE_COS_6_2
+    template<>
+    struct CosTableValueSize<6, 2, true>
+    {
+        typedef CosValuesTableQ6_2 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_6_2
+
+    #if TINYMIND_USE_COS_7_1
+    template<>
+    struct CosTableValueSize<7, 1, true>
+    {
+        typedef CosValuesTableQ7_1 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_7_1
+
+    #if TINYMIND_USE_COS_1_15
+    template<>
+    struct CosTableValueSize<1, 15, true>
+    {
+        typedef CosValuesTableQ1_15 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_1_15
+
+    #if TINYMIND_USE_COS_2_14
+    template<>
+    struct CosTableValueSize<2, 14, true>
+    {
+        typedef CosValuesTableQ2_14 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_2_14
+
+    #if TINYMIND_USE_COS_3_13
+    template<>
+    struct CosTableValueSize<3, 13, true>
+    {
+        typedef CosValuesTableQ3_13 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_3_13
+
+    #if TINYMIND_USE_COS_4_12
+    template<>
+    struct CosTableValueSize<4, 12, true>
+    {
+        typedef CosValuesTableQ4_12 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_4_12
+
+    #if TINYMIND_USE_COS_5_11
+    template<>
+    struct CosTableValueSize<5, 11, true>
+    {
+        typedef CosValuesTableQ5_11 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_5_11
+
+    #if TINYMIND_USE_COS_6_10
+    template<>
+    struct CosTableValueSize<6, 10, true>
+    {
+        typedef CosValuesTableQ6_10 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_6_10
+
+    #if TINYMIND_USE_COS_7_9
+    template<>
+    struct CosTableValueSize<7, 9, true>
+    {
+        typedef CosValuesTableQ7_9 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_7_9
+
+    #if TINYMIND_USE_COS_8_8
+    template<>
+    struct CosTableValueSize<8, 8, true>
+    {
+        typedef CosValuesTableQ8_8 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_8_8
+
+    #if TINYMIND_USE_COS_9_7
+    template<>
+    struct CosTableValueSize<9, 7, true>
+    {
+        typedef CosValuesTableQ9_7 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_9_7
+
+    #if TINYMIND_USE_COS_10_6
+    template<>
+    struct CosTableValueSize<10, 6, true>
+    {
+        typedef CosValuesTableQ10_6 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_10_6
+
+    #if TINYMIND_USE_COS_11_5
+    template<>
+    struct CosTableValueSize<11, 5, true>
+    {
+        typedef CosValuesTableQ11_5 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_11_5
+
+    #if TINYMIND_USE_COS_12_4
+    template<>
+    struct CosTableValueSize<12, 4, true>
+    {
+        typedef CosValuesTableQ12_4 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_12_4
+
+    #if TINYMIND_USE_COS_13_3
+    template<>
+    struct CosTableValueSize<13, 3, true>
+    {
+        typedef CosValuesTableQ13_3 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_13_3
+
+    #if TINYMIND_USE_COS_14_2
+    template<>
+    struct CosTableValueSize<14, 2, true>
+    {
+        typedef CosValuesTableQ14_2 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_14_2
+
+    #if TINYMIND_USE_COS_15_1
+    template<>
+    struct CosTableValueSize<15, 1, true>
+    {
+        typedef CosValuesTableQ15_1 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_15_1
+
+    #if TINYMIND_USE_COS_1_31
+    template<>
+    struct CosTableValueSize<1, 31, true>
+    {
+        typedef CosValuesTableQ1_31 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_1_31
+
+    #if TINYMIND_USE_COS_2_30
+    template<>
+    struct CosTableValueSize<2, 30, true>
+    {
+        typedef CosValuesTableQ2_30 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_2_30
+
+    #if TINYMIND_USE_COS_3_29
+    template<>
+    struct CosTableValueSize<3, 29, true>
+    {
+        typedef CosValuesTableQ3_29 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_3_29
+
+    #if TINYMIND_USE_COS_4_28
+    template<>
+    struct CosTableValueSize<4, 28, true>
+    {
+        typedef CosValuesTableQ4_28 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_4_28
+
+    #if TINYMIND_USE_COS_5_27
+    template<>
+    struct CosTableValueSize<5, 27, true>
+    {
+        typedef CosValuesTableQ5_27 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_5_27
+
+    #if TINYMIND_USE_COS_6_26
+    template<>
+    struct CosTableValueSize<6, 26, true>
+    {
+        typedef CosValuesTableQ6_26 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_6_26
+
+    #if TINYMIND_USE_COS_7_25
+    template<>
+    struct CosTableValueSize<7, 25, true>
+    {
+        typedef CosValuesTableQ7_25 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_7_25
+
+    #if TINYMIND_USE_COS_8_24
+    template<>
+    struct CosTableValueSize<8, 24, true>
+    {
+        typedef CosValuesTableQ8_24 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_8_24
+
+    #if TINYMIND_USE_COS_9_23
+    template<>
+    struct CosTableValueSize<9, 23, true>
+    {
+        typedef CosValuesTableQ9_23 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_9_23
+
+    #if TINYMIND_USE_COS_10_22
+    template<>
+    struct CosTableValueSize<10, 22, true>
+    {
+        typedef CosValuesTableQ10_22 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_10_22
+
+    #if TINYMIND_USE_COS_11_21
+    template<>
+    struct CosTableValueSize<11, 21, true>
+    {
+        typedef CosValuesTableQ11_21 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_11_21
+
+    #if TINYMIND_USE_COS_12_20
+    template<>
+    struct CosTableValueSize<12, 20, true>
+    {
+        typedef CosValuesTableQ12_20 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_12_20
+
+    #if TINYMIND_USE_COS_13_19
+    template<>
+    struct CosTableValueSize<13, 19, true>
+    {
+        typedef CosValuesTableQ13_19 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_13_19
+
+    #if TINYMIND_USE_COS_14_18
+    template<>
+    struct CosTableValueSize<14, 18, true>
+    {
+        typedef CosValuesTableQ14_18 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_14_18
+
+    #if TINYMIND_USE_COS_15_17
+    template<>
+    struct CosTableValueSize<15, 17, true>
+    {
+        typedef CosValuesTableQ15_17 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_15_17
+
+    #if TINYMIND_USE_COS_16_16
+    template<>
+    struct CosTableValueSize<16, 16, true>
+    {
+        typedef CosValuesTableQ16_16 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_16_16
+
+    #if TINYMIND_USE_COS_17_15
+    template<>
+    struct CosTableValueSize<17, 15, true>
+    {
+        typedef CosValuesTableQ17_15 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_17_15
+
+    #if TINYMIND_USE_COS_18_14
+    template<>
+    struct CosTableValueSize<18, 14, true>
+    {
+        typedef CosValuesTableQ18_14 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_18_14
+
+    #if TINYMIND_USE_COS_19_13
+    template<>
+    struct CosTableValueSize<19, 13, true>
+    {
+        typedef CosValuesTableQ19_13 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_19_13
+
+    #if TINYMIND_USE_COS_20_12
+    template<>
+    struct CosTableValueSize<20, 12, true>
+    {
+        typedef CosValuesTableQ20_12 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_20_12
+
+    #if TINYMIND_USE_COS_21_11
+    template<>
+    struct CosTableValueSize<21, 11, true>
+    {
+        typedef CosValuesTableQ21_11 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_21_11
+
+    #if TINYMIND_USE_COS_22_10
+    template<>
+    struct CosTableValueSize<22, 10, true>
+    {
+        typedef CosValuesTableQ22_10 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_22_10
+
+    #if TINYMIND_USE_COS_23_9
+    template<>
+    struct CosTableValueSize<23, 9, true>
+    {
+        typedef CosValuesTableQ23_9 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_23_9
+
+    #if TINYMIND_USE_COS_24_8
+    template<>
+    struct CosTableValueSize<24, 8, true>
+    {
+        typedef CosValuesTableQ24_8 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_24_8
+
+    #if TINYMIND_USE_COS_25_7
+    template<>
+    struct CosTableValueSize<25, 7, true>
+    {
+        typedef CosValuesTableQ25_7 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_25_7
+
+    #if TINYMIND_USE_COS_26_6
+    template<>
+    struct CosTableValueSize<26, 6, true>
+    {
+        typedef CosValuesTableQ26_6 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_26_6
+
+    #if TINYMIND_USE_COS_27_5
+    template<>
+    struct CosTableValueSize<27, 5, true>
+    {
+        typedef CosValuesTableQ27_5 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_27_5
+
+    #if TINYMIND_USE_COS_28_4
+    template<>
+    struct CosTableValueSize<28, 4, true>
+    {
+        typedef CosValuesTableQ28_4 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_28_4
+
+    #if TINYMIND_USE_COS_29_3
+    template<>
+    struct CosTableValueSize<29, 3, true>
+    {
+        typedef CosValuesTableQ29_3 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_29_3
+
+    #if TINYMIND_USE_COS_30_2
+    template<>
+    struct CosTableValueSize<30, 2, true>
+    {
+        typedef CosValuesTableQ30_2 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_30_2
+
+    #if TINYMIND_USE_COS_31_1
+    template<>
+    struct CosTableValueSize<31, 1, true>
+    {
+        typedef CosValuesTableQ31_1 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_31_1
+
+    #if TINYMIND_USE_COS_1_63
+    template<>
+    struct CosTableValueSize<1, 63, true>
+    {
+        typedef CosValuesTableQ1_63 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_1_63
+
+    #if TINYMIND_USE_COS_2_62
+    template<>
+    struct CosTableValueSize<2, 62, true>
+    {
+        typedef CosValuesTableQ2_62 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_2_62
+
+    #if TINYMIND_USE_COS_3_61
+    template<>
+    struct CosTableValueSize<3, 61, true>
+    {
+        typedef CosValuesTableQ3_61 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_3_61
+
+    #if TINYMIND_USE_COS_4_60
+    template<>
+    struct CosTableValueSize<4, 60, true>
+    {
+        typedef CosValuesTableQ4_60 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_4_60
+
+    #if TINYMIND_USE_COS_5_59
+    template<>
+    struct CosTableValueSize<5, 59, true>
+    {
+        typedef CosValuesTableQ5_59 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_5_59
+
+    #if TINYMIND_USE_COS_6_58
+    template<>
+    struct CosTableValueSize<6, 58, true>
+    {
+        typedef CosValuesTableQ6_58 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_6_58
+
+    #if TINYMIND_USE_COS_7_57
+    template<>
+    struct CosTableValueSize<7, 57, true>
+    {
+        typedef CosValuesTableQ7_57 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_7_57
+
+    #if TINYMIND_USE_COS_8_56
+    template<>
+    struct CosTableValueSize<8, 56, true>
+    {
+        typedef CosValuesTableQ8_56 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_8_56
+
+    #if TINYMIND_USE_COS_9_55
+    template<>
+    struct CosTableValueSize<9, 55, true>
+    {
+        typedef CosValuesTableQ9_55 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_9_55
+
+    #if TINYMIND_USE_COS_10_54
+    template<>
+    struct CosTableValueSize<10, 54, true>
+    {
+        typedef CosValuesTableQ10_54 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_10_54
+
+    #if TINYMIND_USE_COS_11_53
+    template<>
+    struct CosTableValueSize<11, 53, true>
+    {
+        typedef CosValuesTableQ11_53 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_11_53
+
+    #if TINYMIND_USE_COS_12_52
+    template<>
+    struct CosTableValueSize<12, 52, true>
+    {
+        typedef CosValuesTableQ12_52 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_12_52
+
+    #if TINYMIND_USE_COS_13_51
+    template<>
+    struct CosTableValueSize<13, 51, true>
+    {
+        typedef CosValuesTableQ13_51 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_13_51
+
+    #if TINYMIND_USE_COS_14_50
+    template<>
+    struct CosTableValueSize<14, 50, true>
+    {
+        typedef CosValuesTableQ14_50 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_14_50
+
+    #if TINYMIND_USE_COS_15_49
+    template<>
+    struct CosTableValueSize<15, 49, true>
+    {
+        typedef CosValuesTableQ15_49 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_15_49
+
+    #if TINYMIND_USE_COS_16_48
+    template<>
+    struct CosTableValueSize<16, 48, true>
+    {
+        typedef CosValuesTableQ16_48 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_16_48
+
+    #if TINYMIND_USE_COS_17_47
+    template<>
+    struct CosTableValueSize<17, 47, true>
+    {
+        typedef CosValuesTableQ17_47 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_17_47
+
+    #if TINYMIND_USE_COS_18_46
+    template<>
+    struct CosTableValueSize<18, 46, true>
+    {
+        typedef CosValuesTableQ18_46 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_18_46
+
+    #if TINYMIND_USE_COS_19_45
+    template<>
+    struct CosTableValueSize<19, 45, true>
+    {
+        typedef CosValuesTableQ19_45 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_19_45
+
+    #if TINYMIND_USE_COS_20_44
+    template<>
+    struct CosTableValueSize<20, 44, true>
+    {
+        typedef CosValuesTableQ20_44 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_20_44
+
+    #if TINYMIND_USE_COS_21_43
+    template<>
+    struct CosTableValueSize<21, 43, true>
+    {
+        typedef CosValuesTableQ21_43 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_21_43
+
+    #if TINYMIND_USE_COS_22_42
+    template<>
+    struct CosTableValueSize<22, 42, true>
+    {
+        typedef CosValuesTableQ22_42 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_22_42
+
+    #if TINYMIND_USE_COS_23_41
+    template<>
+    struct CosTableValueSize<23, 41, true>
+    {
+        typedef CosValuesTableQ23_41 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_23_41
+
+    #if TINYMIND_USE_COS_24_40
+    template<>
+    struct CosTableValueSize<24, 40, true>
+    {
+        typedef CosValuesTableQ24_40 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_24_40
+
+    #if TINYMIND_USE_COS_25_39
+    template<>
+    struct CosTableValueSize<25, 39, true>
+    {
+        typedef CosValuesTableQ25_39 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_25_39
+
+    #if TINYMIND_USE_COS_26_38
+    template<>
+    struct CosTableValueSize<26, 38, true>
+    {
+        typedef CosValuesTableQ26_38 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_26_38
+
+    #if TINYMIND_USE_COS_27_37
+    template<>
+    struct CosTableValueSize<27, 37, true>
+    {
+        typedef CosValuesTableQ27_37 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_27_37
+
+    #if TINYMIND_USE_COS_28_36
+    template<>
+    struct CosTableValueSize<28, 36, true>
+    {
+        typedef CosValuesTableQ28_36 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_28_36
+
+    #if TINYMIND_USE_COS_29_35
+    template<>
+    struct CosTableValueSize<29, 35, true>
+    {
+        typedef CosValuesTableQ29_35 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_29_35
+
+    #if TINYMIND_USE_COS_30_34
+    template<>
+    struct CosTableValueSize<30, 34, true>
+    {
+        typedef CosValuesTableQ30_34 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_30_34
+
+    #if TINYMIND_USE_COS_31_33
+    template<>
+    struct CosTableValueSize<31, 33, true>
+    {
+        typedef CosValuesTableQ31_33 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_31_33
+
+    #if TINYMIND_USE_COS_32_32
+    template<>
+    struct CosTableValueSize<32, 32, true>
+    {
+        typedef CosValuesTableQ32_32 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_32_32
+
+    #if TINYMIND_USE_COS_33_31
+    template<>
+    struct CosTableValueSize<33, 31, true>
+    {
+        typedef CosValuesTableQ33_31 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_33_31
+
+    #if TINYMIND_USE_COS_34_30
+    template<>
+    struct CosTableValueSize<34, 30, true>
+    {
+        typedef CosValuesTableQ34_30 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_34_30
+
+    #if TINYMIND_USE_COS_35_29
+    template<>
+    struct CosTableValueSize<35, 29, true>
+    {
+        typedef CosValuesTableQ35_29 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_35_29
+
+    #if TINYMIND_USE_COS_36_28
+    template<>
+    struct CosTableValueSize<36, 28, true>
+    {
+        typedef CosValuesTableQ36_28 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_36_28
+
+    #if TINYMIND_USE_COS_37_27
+    template<>
+    struct CosTableValueSize<37, 27, true>
+    {
+        typedef CosValuesTableQ37_27 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_37_27
+
+    #if TINYMIND_USE_COS_38_26
+    template<>
+    struct CosTableValueSize<38, 26, true>
+    {
+        typedef CosValuesTableQ38_26 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_38_26
+
+    #if TINYMIND_USE_COS_39_25
+    template<>
+    struct CosTableValueSize<39, 25, true>
+    {
+        typedef CosValuesTableQ39_25 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_39_25
+
+    #if TINYMIND_USE_COS_40_24
+    template<>
+    struct CosTableValueSize<40, 24, true>
+    {
+        typedef CosValuesTableQ40_24 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_40_24
+
+    #if TINYMIND_USE_COS_41_23
+    template<>
+    struct CosTableValueSize<41, 23, true>
+    {
+        typedef CosValuesTableQ41_23 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_41_23
+
+    #if TINYMIND_USE_COS_42_22
+    template<>
+    struct CosTableValueSize<42, 22, true>
+    {
+        typedef CosValuesTableQ42_22 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_42_22
+
+    #if TINYMIND_USE_COS_43_21
+    template<>
+    struct CosTableValueSize<43, 21, true>
+    {
+        typedef CosValuesTableQ43_21 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_43_21
+
+    #if TINYMIND_USE_COS_44_20
+    template<>
+    struct CosTableValueSize<44, 20, true>
+    {
+        typedef CosValuesTableQ44_20 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_44_20
+
+    #if TINYMIND_USE_COS_45_19
+    template<>
+    struct CosTableValueSize<45, 19, true>
+    {
+        typedef CosValuesTableQ45_19 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_45_19
+
+    #if TINYMIND_USE_COS_46_18
+    template<>
+    struct CosTableValueSize<46, 18, true>
+    {
+        typedef CosValuesTableQ46_18 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_46_18
+
+    #if TINYMIND_USE_COS_47_17
+    template<>
+    struct CosTableValueSize<47, 17, true>
+    {
+        typedef CosValuesTableQ47_17 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_47_17
+
+    #if TINYMIND_USE_COS_48_16
+    template<>
+    struct CosTableValueSize<48, 16, true>
+    {
+        typedef CosValuesTableQ48_16 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_48_16
+
+    #if TINYMIND_USE_COS_49_15
+    template<>
+    struct CosTableValueSize<49, 15, true>
+    {
+        typedef CosValuesTableQ49_15 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_49_15
+
+    #if TINYMIND_USE_COS_50_14
+    template<>
+    struct CosTableValueSize<50, 14, true>
+    {
+        typedef CosValuesTableQ50_14 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_50_14
+
+    #if TINYMIND_USE_COS_51_13
+    template<>
+    struct CosTableValueSize<51, 13, true>
+    {
+        typedef CosValuesTableQ51_13 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_51_13
+
+    #if TINYMIND_USE_COS_52_12
+    template<>
+    struct CosTableValueSize<52, 12, true>
+    {
+        typedef CosValuesTableQ52_12 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_52_12
+
+    #if TINYMIND_USE_COS_53_11
+    template<>
+    struct CosTableValueSize<53, 11, true>
+    {
+        typedef CosValuesTableQ53_11 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_53_11
+
+    #if TINYMIND_USE_COS_54_10
+    template<>
+    struct CosTableValueSize<54, 10, true>
+    {
+        typedef CosValuesTableQ54_10 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_54_10
+
+    #if TINYMIND_USE_COS_55_9
+    template<>
+    struct CosTableValueSize<55, 9, true>
+    {
+        typedef CosValuesTableQ55_9 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_55_9
+
+    #if TINYMIND_USE_COS_56_8
+    template<>
+    struct CosTableValueSize<56, 8, true>
+    {
+        typedef CosValuesTableQ56_8 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_56_8
+
+    #if TINYMIND_USE_COS_57_7
+    template<>
+    struct CosTableValueSize<57, 7, true>
+    {
+        typedef CosValuesTableQ57_7 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_57_7
+
+    #if TINYMIND_USE_COS_58_6
+    template<>
+    struct CosTableValueSize<58, 6, true>
+    {
+        typedef CosValuesTableQ58_6 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_58_6
+
+    #if TINYMIND_USE_COS_59_5
+    template<>
+    struct CosTableValueSize<59, 5, true>
+    {
+        typedef CosValuesTableQ59_5 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_59_5
+
+    #if TINYMIND_USE_COS_60_4
+    template<>
+    struct CosTableValueSize<60, 4, true>
+    {
+        typedef CosValuesTableQ60_4 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_60_4
+
+    #if TINYMIND_USE_COS_61_3
+    template<>
+    struct CosTableValueSize<61, 3, true>
+    {
+        typedef CosValuesTableQ61_3 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_61_3
+
+    #if TINYMIND_USE_COS_62_2
+    template<>
+    struct CosTableValueSize<62, 2, true>
+    {
+        typedef CosValuesTableQ62_2 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_62_2
+
+    #if TINYMIND_USE_COS_63_1
+    template<>
+    struct CosTableValueSize<63, 1, true>
+    {
+        typedef CosValuesTableQ63_1 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_63_1
+
+    #if TINYMIND_USE_COS_1_127
+    template<>
+    struct CosTableValueSize<1, 127, true>
+    {
+        typedef CosValuesTableQ1_127 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_1_127
+
+    #if TINYMIND_USE_COS_2_126
+    template<>
+    struct CosTableValueSize<2, 126, true>
+    {
+        typedef CosValuesTableQ2_126 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_2_126
+
+    #if TINYMIND_USE_COS_3_125
+    template<>
+    struct CosTableValueSize<3, 125, true>
+    {
+        typedef CosValuesTableQ3_125 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_3_125
+
+    #if TINYMIND_USE_COS_4_124
+    template<>
+    struct CosTableValueSize<4, 124, true>
+    {
+        typedef CosValuesTableQ4_124 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_4_124
+
+    #if TINYMIND_USE_COS_5_123
+    template<>
+    struct CosTableValueSize<5, 123, true>
+    {
+        typedef CosValuesTableQ5_123 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_5_123
+
+    #if TINYMIND_USE_COS_6_122
+    template<>
+    struct CosTableValueSize<6, 122, true>
+    {
+        typedef CosValuesTableQ6_122 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_6_122
+
+    #if TINYMIND_USE_COS_7_121
+    template<>
+    struct CosTableValueSize<7, 121, true>
+    {
+        typedef CosValuesTableQ7_121 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_7_121
+
+    #if TINYMIND_USE_COS_8_120
+    template<>
+    struct CosTableValueSize<8, 120, true>
+    {
+        typedef CosValuesTableQ8_120 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_8_120
+
+    #if TINYMIND_USE_COS_9_119
+    template<>
+    struct CosTableValueSize<9, 119, true>
+    {
+        typedef CosValuesTableQ9_119 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_9_119
+
+    #if TINYMIND_USE_COS_10_118
+    template<>
+    struct CosTableValueSize<10, 118, true>
+    {
+        typedef CosValuesTableQ10_118 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_10_118
+
+    #if TINYMIND_USE_COS_11_117
+    template<>
+    struct CosTableValueSize<11, 117, true>
+    {
+        typedef CosValuesTableQ11_117 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_11_117
+
+    #if TINYMIND_USE_COS_12_116
+    template<>
+    struct CosTableValueSize<12, 116, true>
+    {
+        typedef CosValuesTableQ12_116 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_12_116
+
+    #if TINYMIND_USE_COS_13_115
+    template<>
+    struct CosTableValueSize<13, 115, true>
+    {
+        typedef CosValuesTableQ13_115 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_13_115
+
+    #if TINYMIND_USE_COS_14_114
+    template<>
+    struct CosTableValueSize<14, 114, true>
+    {
+        typedef CosValuesTableQ14_114 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_14_114
+
+    #if TINYMIND_USE_COS_15_113
+    template<>
+    struct CosTableValueSize<15, 113, true>
+    {
+        typedef CosValuesTableQ15_113 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_15_113
+
+    #if TINYMIND_USE_COS_16_112
+    template<>
+    struct CosTableValueSize<16, 112, true>
+    {
+        typedef CosValuesTableQ16_112 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_16_112
+
+    #if TINYMIND_USE_COS_17_111
+    template<>
+    struct CosTableValueSize<17, 111, true>
+    {
+        typedef CosValuesTableQ17_111 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_17_111
+
+    #if TINYMIND_USE_COS_18_110
+    template<>
+    struct CosTableValueSize<18, 110, true>
+    {
+        typedef CosValuesTableQ18_110 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_18_110
+
+    #if TINYMIND_USE_COS_19_109
+    template<>
+    struct CosTableValueSize<19, 109, true>
+    {
+        typedef CosValuesTableQ19_109 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_19_109
+
+    #if TINYMIND_USE_COS_20_108
+    template<>
+    struct CosTableValueSize<20, 108, true>
+    {
+        typedef CosValuesTableQ20_108 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_20_108
+
+    #if TINYMIND_USE_COS_21_107
+    template<>
+    struct CosTableValueSize<21, 107, true>
+    {
+        typedef CosValuesTableQ21_107 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_21_107
+
+    #if TINYMIND_USE_COS_22_106
+    template<>
+    struct CosTableValueSize<22, 106, true>
+    {
+        typedef CosValuesTableQ22_106 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_22_106
+
+    #if TINYMIND_USE_COS_23_105
+    template<>
+    struct CosTableValueSize<23, 105, true>
+    {
+        typedef CosValuesTableQ23_105 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_23_105
+
+    #if TINYMIND_USE_COS_24_104
+    template<>
+    struct CosTableValueSize<24, 104, true>
+    {
+        typedef CosValuesTableQ24_104 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_24_104
+
+    #if TINYMIND_USE_COS_25_103
+    template<>
+    struct CosTableValueSize<25, 103, true>
+    {
+        typedef CosValuesTableQ25_103 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_25_103
+
+    #if TINYMIND_USE_COS_26_102
+    template<>
+    struct CosTableValueSize<26, 102, true>
+    {
+        typedef CosValuesTableQ26_102 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_26_102
+
+    #if TINYMIND_USE_COS_27_101
+    template<>
+    struct CosTableValueSize<27, 101, true>
+    {
+        typedef CosValuesTableQ27_101 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_27_101
+
+    #if TINYMIND_USE_COS_28_100
+    template<>
+    struct CosTableValueSize<28, 100, true>
+    {
+        typedef CosValuesTableQ28_100 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_28_100
+
+    #if TINYMIND_USE_COS_29_99
+    template<>
+    struct CosTableValueSize<29, 99, true>
+    {
+        typedef CosValuesTableQ29_99 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_29_99
+
+    #if TINYMIND_USE_COS_30_98
+    template<>
+    struct CosTableValueSize<30, 98, true>
+    {
+        typedef CosValuesTableQ30_98 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_30_98
+
+    #if TINYMIND_USE_COS_31_97
+    template<>
+    struct CosTableValueSize<31, 97, true>
+    {
+        typedef CosValuesTableQ31_97 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_31_97
+
+    #if TINYMIND_USE_COS_32_96
+    template<>
+    struct CosTableValueSize<32, 96, true>
+    {
+        typedef CosValuesTableQ32_96 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_32_96
+
+    #if TINYMIND_USE_COS_33_95
+    template<>
+    struct CosTableValueSize<33, 95, true>
+    {
+        typedef CosValuesTableQ33_95 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_33_95
+
+    #if TINYMIND_USE_COS_34_94
+    template<>
+    struct CosTableValueSize<34, 94, true>
+    {
+        typedef CosValuesTableQ34_94 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_34_94
+
+    #if TINYMIND_USE_COS_35_93
+    template<>
+    struct CosTableValueSize<35, 93, true>
+    {
+        typedef CosValuesTableQ35_93 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_35_93
+
+    #if TINYMIND_USE_COS_36_92
+    template<>
+    struct CosTableValueSize<36, 92, true>
+    {
+        typedef CosValuesTableQ36_92 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_36_92
+
+    #if TINYMIND_USE_COS_37_91
+    template<>
+    struct CosTableValueSize<37, 91, true>
+    {
+        typedef CosValuesTableQ37_91 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_37_91
+
+    #if TINYMIND_USE_COS_38_90
+    template<>
+    struct CosTableValueSize<38, 90, true>
+    {
+        typedef CosValuesTableQ38_90 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_38_90
+
+    #if TINYMIND_USE_COS_39_89
+    template<>
+    struct CosTableValueSize<39, 89, true>
+    {
+        typedef CosValuesTableQ39_89 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_39_89
+
+    #if TINYMIND_USE_COS_40_88
+    template<>
+    struct CosTableValueSize<40, 88, true>
+    {
+        typedef CosValuesTableQ40_88 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_40_88
+
+    #if TINYMIND_USE_COS_41_87
+    template<>
+    struct CosTableValueSize<41, 87, true>
+    {
+        typedef CosValuesTableQ41_87 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_41_87
+
+    #if TINYMIND_USE_COS_42_86
+    template<>
+    struct CosTableValueSize<42, 86, true>
+    {
+        typedef CosValuesTableQ42_86 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_42_86
+
+    #if TINYMIND_USE_COS_43_85
+    template<>
+    struct CosTableValueSize<43, 85, true>
+    {
+        typedef CosValuesTableQ43_85 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_43_85
+
+    #if TINYMIND_USE_COS_44_84
+    template<>
+    struct CosTableValueSize<44, 84, true>
+    {
+        typedef CosValuesTableQ44_84 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_44_84
+
+    #if TINYMIND_USE_COS_45_83
+    template<>
+    struct CosTableValueSize<45, 83, true>
+    {
+        typedef CosValuesTableQ45_83 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_45_83
+
+    #if TINYMIND_USE_COS_46_82
+    template<>
+    struct CosTableValueSize<46, 82, true>
+    {
+        typedef CosValuesTableQ46_82 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_46_82
+
+    #if TINYMIND_USE_COS_47_81
+    template<>
+    struct CosTableValueSize<47, 81, true>
+    {
+        typedef CosValuesTableQ47_81 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_47_81
+
+    #if TINYMIND_USE_COS_48_80
+    template<>
+    struct CosTableValueSize<48, 80, true>
+    {
+        typedef CosValuesTableQ48_80 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_48_80
+
+    #if TINYMIND_USE_COS_49_79
+    template<>
+    struct CosTableValueSize<49, 79, true>
+    {
+        typedef CosValuesTableQ49_79 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_49_79
+
+    #if TINYMIND_USE_COS_50_78
+    template<>
+    struct CosTableValueSize<50, 78, true>
+    {
+        typedef CosValuesTableQ50_78 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_50_78
+
+    #if TINYMIND_USE_COS_51_77
+    template<>
+    struct CosTableValueSize<51, 77, true>
+    {
+        typedef CosValuesTableQ51_77 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_51_77
+
+    #if TINYMIND_USE_COS_52_76
+    template<>
+    struct CosTableValueSize<52, 76, true>
+    {
+        typedef CosValuesTableQ52_76 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_52_76
+
+    #if TINYMIND_USE_COS_53_75
+    template<>
+    struct CosTableValueSize<53, 75, true>
+    {
+        typedef CosValuesTableQ53_75 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_53_75
+
+    #if TINYMIND_USE_COS_54_74
+    template<>
+    struct CosTableValueSize<54, 74, true>
+    {
+        typedef CosValuesTableQ54_74 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_54_74
+
+    #if TINYMIND_USE_COS_55_73
+    template<>
+    struct CosTableValueSize<55, 73, true>
+    {
+        typedef CosValuesTableQ55_73 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_55_73
+
+    #if TINYMIND_USE_COS_56_72
+    template<>
+    struct CosTableValueSize<56, 72, true>
+    {
+        typedef CosValuesTableQ56_72 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_56_72
+
+    #if TINYMIND_USE_COS_57_71
+    template<>
+    struct CosTableValueSize<57, 71, true>
+    {
+        typedef CosValuesTableQ57_71 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_57_71
+
+    #if TINYMIND_USE_COS_58_70
+    template<>
+    struct CosTableValueSize<58, 70, true>
+    {
+        typedef CosValuesTableQ58_70 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_58_70
+
+    #if TINYMIND_USE_COS_59_69
+    template<>
+    struct CosTableValueSize<59, 69, true>
+    {
+        typedef CosValuesTableQ59_69 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_59_69
+
+    #if TINYMIND_USE_COS_60_68
+    template<>
+    struct CosTableValueSize<60, 68, true>
+    {
+        typedef CosValuesTableQ60_68 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_60_68
+
+    #if TINYMIND_USE_COS_61_67
+    template<>
+    struct CosTableValueSize<61, 67, true>
+    {
+        typedef CosValuesTableQ61_67 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_61_67
+
+    #if TINYMIND_USE_COS_62_66
+    template<>
+    struct CosTableValueSize<62, 66, true>
+    {
+        typedef CosValuesTableQ62_66 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_62_66
+
+    #if TINYMIND_USE_COS_63_65
+    template<>
+    struct CosTableValueSize<63, 65, true>
+    {
+        typedef CosValuesTableQ63_65 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_63_65
+
+    #if TINYMIND_USE_COS_64_64
+    template<>
+    struct CosTableValueSize<64, 64, true>
+    {
+        typedef CosValuesTableQ64_64 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_64_64
+
+    #if TINYMIND_USE_COS_65_63
+    template<>
+    struct CosTableValueSize<65, 63, true>
+    {
+        typedef CosValuesTableQ65_63 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_65_63
+
+    #if TINYMIND_USE_COS_66_62
+    template<>
+    struct CosTableValueSize<66, 62, true>
+    {
+        typedef CosValuesTableQ66_62 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_66_62
+
+    #if TINYMIND_USE_COS_67_61
+    template<>
+    struct CosTableValueSize<67, 61, true>
+    {
+        typedef CosValuesTableQ67_61 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_67_61
+
+    #if TINYMIND_USE_COS_68_60
+    template<>
+    struct CosTableValueSize<68, 60, true>
+    {
+        typedef CosValuesTableQ68_60 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_68_60
+
+    #if TINYMIND_USE_COS_69_59
+    template<>
+    struct CosTableValueSize<69, 59, true>
+    {
+        typedef CosValuesTableQ69_59 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_69_59
+
+    #if TINYMIND_USE_COS_70_58
+    template<>
+    struct CosTableValueSize<70, 58, true>
+    {
+        typedef CosValuesTableQ70_58 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_70_58
+
+    #if TINYMIND_USE_COS_71_57
+    template<>
+    struct CosTableValueSize<71, 57, true>
+    {
+        typedef CosValuesTableQ71_57 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_71_57
+
+    #if TINYMIND_USE_COS_72_56
+    template<>
+    struct CosTableValueSize<72, 56, true>
+    {
+        typedef CosValuesTableQ72_56 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_72_56
+
+    #if TINYMIND_USE_COS_73_55
+    template<>
+    struct CosTableValueSize<73, 55, true>
+    {
+        typedef CosValuesTableQ73_55 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_73_55
+
+    #if TINYMIND_USE_COS_74_54
+    template<>
+    struct CosTableValueSize<74, 54, true>
+    {
+        typedef CosValuesTableQ74_54 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_74_54
+
+    #if TINYMIND_USE_COS_75_53
+    template<>
+    struct CosTableValueSize<75, 53, true>
+    {
+        typedef CosValuesTableQ75_53 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_75_53
+
+    #if TINYMIND_USE_COS_76_52
+    template<>
+    struct CosTableValueSize<76, 52, true>
+    {
+        typedef CosValuesTableQ76_52 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_76_52
+
+    #if TINYMIND_USE_COS_77_51
+    template<>
+    struct CosTableValueSize<77, 51, true>
+    {
+        typedef CosValuesTableQ77_51 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_77_51
+
+    #if TINYMIND_USE_COS_78_50
+    template<>
+    struct CosTableValueSize<78, 50, true>
+    {
+        typedef CosValuesTableQ78_50 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_78_50
+
+    #if TINYMIND_USE_COS_79_49
+    template<>
+    struct CosTableValueSize<79, 49, true>
+    {
+        typedef CosValuesTableQ79_49 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_79_49
+
+    #if TINYMIND_USE_COS_80_48
+    template<>
+    struct CosTableValueSize<80, 48, true>
+    {
+        typedef CosValuesTableQ80_48 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_80_48
+
+    #if TINYMIND_USE_COS_81_47
+    template<>
+    struct CosTableValueSize<81, 47, true>
+    {
+        typedef CosValuesTableQ81_47 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_81_47
+
+    #if TINYMIND_USE_COS_82_46
+    template<>
+    struct CosTableValueSize<82, 46, true>
+    {
+        typedef CosValuesTableQ82_46 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_82_46
+
+    #if TINYMIND_USE_COS_83_45
+    template<>
+    struct CosTableValueSize<83, 45, true>
+    {
+        typedef CosValuesTableQ83_45 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_83_45
+
+    #if TINYMIND_USE_COS_84_44
+    template<>
+    struct CosTableValueSize<84, 44, true>
+    {
+        typedef CosValuesTableQ84_44 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_84_44
+
+    #if TINYMIND_USE_COS_85_43
+    template<>
+    struct CosTableValueSize<85, 43, true>
+    {
+        typedef CosValuesTableQ85_43 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_85_43
+
+    #if TINYMIND_USE_COS_86_42
+    template<>
+    struct CosTableValueSize<86, 42, true>
+    {
+        typedef CosValuesTableQ86_42 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_86_42
+
+    #if TINYMIND_USE_COS_87_41
+    template<>
+    struct CosTableValueSize<87, 41, true>
+    {
+        typedef CosValuesTableQ87_41 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_87_41
+
+    #if TINYMIND_USE_COS_88_40
+    template<>
+    struct CosTableValueSize<88, 40, true>
+    {
+        typedef CosValuesTableQ88_40 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_88_40
+
+    #if TINYMIND_USE_COS_89_39
+    template<>
+    struct CosTableValueSize<89, 39, true>
+    {
+        typedef CosValuesTableQ89_39 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_89_39
+
+    #if TINYMIND_USE_COS_90_38
+    template<>
+    struct CosTableValueSize<90, 38, true>
+    {
+        typedef CosValuesTableQ90_38 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_90_38
+
+    #if TINYMIND_USE_COS_91_37
+    template<>
+    struct CosTableValueSize<91, 37, true>
+    {
+        typedef CosValuesTableQ91_37 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_91_37
+
+    #if TINYMIND_USE_COS_92_36
+    template<>
+    struct CosTableValueSize<92, 36, true>
+    {
+        typedef CosValuesTableQ92_36 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_92_36
+
+    #if TINYMIND_USE_COS_93_35
+    template<>
+    struct CosTableValueSize<93, 35, true>
+    {
+        typedef CosValuesTableQ93_35 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_93_35
+
+    #if TINYMIND_USE_COS_94_34
+    template<>
+    struct CosTableValueSize<94, 34, true>
+    {
+        typedef CosValuesTableQ94_34 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_94_34
+
+    #if TINYMIND_USE_COS_95_33
+    template<>
+    struct CosTableValueSize<95, 33, true>
+    {
+        typedef CosValuesTableQ95_33 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_95_33
+
+    #if TINYMIND_USE_COS_96_32
+    template<>
+    struct CosTableValueSize<96, 32, true>
+    {
+        typedef CosValuesTableQ96_32 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_96_32
+
+    #if TINYMIND_USE_COS_97_31
+    template<>
+    struct CosTableValueSize<97, 31, true>
+    {
+        typedef CosValuesTableQ97_31 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_97_31
+
+    #if TINYMIND_USE_COS_98_30
+    template<>
+    struct CosTableValueSize<98, 30, true>
+    {
+        typedef CosValuesTableQ98_30 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_98_30
+
+    #if TINYMIND_USE_COS_99_29
+    template<>
+    struct CosTableValueSize<99, 29, true>
+    {
+        typedef CosValuesTableQ99_29 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_99_29
+
+    #if TINYMIND_USE_COS_100_28
+    template<>
+    struct CosTableValueSize<100, 28, true>
+    {
+        typedef CosValuesTableQ100_28 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_100_28
+
+    #if TINYMIND_USE_COS_101_27
+    template<>
+    struct CosTableValueSize<101, 27, true>
+    {
+        typedef CosValuesTableQ101_27 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_101_27
+
+    #if TINYMIND_USE_COS_102_26
+    template<>
+    struct CosTableValueSize<102, 26, true>
+    {
+        typedef CosValuesTableQ102_26 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_102_26
+
+    #if TINYMIND_USE_COS_103_25
+    template<>
+    struct CosTableValueSize<103, 25, true>
+    {
+        typedef CosValuesTableQ103_25 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_103_25
+
+    #if TINYMIND_USE_COS_104_24
+    template<>
+    struct CosTableValueSize<104, 24, true>
+    {
+        typedef CosValuesTableQ104_24 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_104_24
+
+    #if TINYMIND_USE_COS_105_23
+    template<>
+    struct CosTableValueSize<105, 23, true>
+    {
+        typedef CosValuesTableQ105_23 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_105_23
+
+    #if TINYMIND_USE_COS_106_22
+    template<>
+    struct CosTableValueSize<106, 22, true>
+    {
+        typedef CosValuesTableQ106_22 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_106_22
+
+    #if TINYMIND_USE_COS_107_21
+    template<>
+    struct CosTableValueSize<107, 21, true>
+    {
+        typedef CosValuesTableQ107_21 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_107_21
+
+    #if TINYMIND_USE_COS_108_20
+    template<>
+    struct CosTableValueSize<108, 20, true>
+    {
+        typedef CosValuesTableQ108_20 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_108_20
+
+    #if TINYMIND_USE_COS_109_19
+    template<>
+    struct CosTableValueSize<109, 19, true>
+    {
+        typedef CosValuesTableQ109_19 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_109_19
+
+    #if TINYMIND_USE_COS_110_18
+    template<>
+    struct CosTableValueSize<110, 18, true>
+    {
+        typedef CosValuesTableQ110_18 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_110_18
+
+    #if TINYMIND_USE_COS_111_17
+    template<>
+    struct CosTableValueSize<111, 17, true>
+    {
+        typedef CosValuesTableQ111_17 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_111_17
+
+    #if TINYMIND_USE_COS_112_16
+    template<>
+    struct CosTableValueSize<112, 16, true>
+    {
+        typedef CosValuesTableQ112_16 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_112_16
+
+    #if TINYMIND_USE_COS_113_15
+    template<>
+    struct CosTableValueSize<113, 15, true>
+    {
+        typedef CosValuesTableQ113_15 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_113_15
+
+    #if TINYMIND_USE_COS_114_14
+    template<>
+    struct CosTableValueSize<114, 14, true>
+    {
+        typedef CosValuesTableQ114_14 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_114_14
+
+    #if TINYMIND_USE_COS_115_13
+    template<>
+    struct CosTableValueSize<115, 13, true>
+    {
+        typedef CosValuesTableQ115_13 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_115_13
+
+    #if TINYMIND_USE_COS_116_12
+    template<>
+    struct CosTableValueSize<116, 12, true>
+    {
+        typedef CosValuesTableQ116_12 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_116_12
+
+    #if TINYMIND_USE_COS_117_11
+    template<>
+    struct CosTableValueSize<117, 11, true>
+    {
+        typedef CosValuesTableQ117_11 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_117_11
+
+    #if TINYMIND_USE_COS_118_10
+    template<>
+    struct CosTableValueSize<118, 10, true>
+    {
+        typedef CosValuesTableQ118_10 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_118_10
+
+    #if TINYMIND_USE_COS_119_9
+    template<>
+    struct CosTableValueSize<119, 9, true>
+    {
+        typedef CosValuesTableQ119_9 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_119_9
+
+    #if TINYMIND_USE_COS_120_8
+    template<>
+    struct CosTableValueSize<120, 8, true>
+    {
+        typedef CosValuesTableQ120_8 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_120_8
+
+    #if TINYMIND_USE_COS_121_7
+    template<>
+    struct CosTableValueSize<121, 7, true>
+    {
+        typedef CosValuesTableQ121_7 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_121_7
+
+    #if TINYMIND_USE_COS_122_6
+    template<>
+    struct CosTableValueSize<122, 6, true>
+    {
+        typedef CosValuesTableQ122_6 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_122_6
+
+    #if TINYMIND_USE_COS_123_5
+    template<>
+    struct CosTableValueSize<123, 5, true>
+    {
+        typedef CosValuesTableQ123_5 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_123_5
+
+    #if TINYMIND_USE_COS_124_4
+    template<>
+    struct CosTableValueSize<124, 4, true>
+    {
+        typedef CosValuesTableQ124_4 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_124_4
+
+    #if TINYMIND_USE_COS_125_3
+    template<>
+    struct CosTableValueSize<125, 3, true>
+    {
+        typedef CosValuesTableQ125_3 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_125_3
+
+    #if TINYMIND_USE_COS_126_2
+    template<>
+    struct CosTableValueSize<126, 2, true>
+    {
+        typedef CosValuesTableQ126_2 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_126_2
+
+    #if TINYMIND_USE_COS_127_1
+    template<>
+    struct CosTableValueSize<127, 1, true>
+    {
+        typedef CosValuesTableQ127_1 CosTableType;
+    };
+    #endif // TINYMIND_USE_COS_127_1
+
+    template<unsigned FixedBits,unsigned FracBits, bool IsSigned>
+    struct CosValuesTableSelector
+    {
+        typedef typename CosTableValueSize<FixedBits, FracBits, IsSigned>::CosTableType CosTableType;
+    };
+}

--- a/cpp/cos.hpp
+++ b/cpp/cos.hpp
@@ -19,27 +19,6 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 * SOFTWARE.
 */
-/**
-* Copyright (c) 2020 Intel Corporation
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
 
 #pragma once
 

--- a/cpp/cosValues128Bit.hpp
+++ b/cpp/cosValues128Bit.hpp
@@ -19,27 +19,6 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 * SOFTWARE.
 */
-/**
-* Copyright (c) 2020 Intel Corporation
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
 
 #pragma once
 

--- a/cpp/cosValues128Bit.hpp
+++ b/cpp/cosValues128Bit.hpp
@@ -1,0 +1,811 @@
+/**
+* Copyright (c) 2026 Dan McLeran
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+/**
+* Copyright (c) 2020 Intel Corporation
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#pragma once
+
+#include "activation.hpp"
+
+namespace tinymind {
+    #if TINYMIND_USE_COS_1_127
+    struct CosValuesTableQ1_127
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_1_127
+    #if TINYMIND_USE_COS_2_126
+    struct CosValuesTableQ2_126
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_2_126
+    #if TINYMIND_USE_COS_3_125
+    struct CosValuesTableQ3_125
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_3_125
+    #if TINYMIND_USE_COS_4_124
+    struct CosValuesTableQ4_124
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_4_124
+    #if TINYMIND_USE_COS_5_123
+    struct CosValuesTableQ5_123
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_5_123
+    #if TINYMIND_USE_COS_6_122
+    struct CosValuesTableQ6_122
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_6_122
+    #if TINYMIND_USE_COS_7_121
+    struct CosValuesTableQ7_121
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_7_121
+    #if TINYMIND_USE_COS_8_120
+    struct CosValuesTableQ8_120
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_8_120
+    #if TINYMIND_USE_COS_9_119
+    struct CosValuesTableQ9_119
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_9_119
+    #if TINYMIND_USE_COS_10_118
+    struct CosValuesTableQ10_118
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_10_118
+    #if TINYMIND_USE_COS_11_117
+    struct CosValuesTableQ11_117
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_11_117
+    #if TINYMIND_USE_COS_12_116
+    struct CosValuesTableQ12_116
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_12_116
+    #if TINYMIND_USE_COS_13_115
+    struct CosValuesTableQ13_115
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_13_115
+    #if TINYMIND_USE_COS_14_114
+    struct CosValuesTableQ14_114
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_14_114
+    #if TINYMIND_USE_COS_15_113
+    struct CosValuesTableQ15_113
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_15_113
+    #if TINYMIND_USE_COS_16_112
+    struct CosValuesTableQ16_112
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_16_112
+    #if TINYMIND_USE_COS_17_111
+    struct CosValuesTableQ17_111
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_17_111
+    #if TINYMIND_USE_COS_18_110
+    struct CosValuesTableQ18_110
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_18_110
+    #if TINYMIND_USE_COS_19_109
+    struct CosValuesTableQ19_109
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_19_109
+    #if TINYMIND_USE_COS_20_108
+    struct CosValuesTableQ20_108
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_20_108
+    #if TINYMIND_USE_COS_21_107
+    struct CosValuesTableQ21_107
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_21_107
+    #if TINYMIND_USE_COS_22_106
+    struct CosValuesTableQ22_106
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_22_106
+    #if TINYMIND_USE_COS_23_105
+    struct CosValuesTableQ23_105
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_23_105
+    #if TINYMIND_USE_COS_24_104
+    struct CosValuesTableQ24_104
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_24_104
+    #if TINYMIND_USE_COS_25_103
+    struct CosValuesTableQ25_103
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_25_103
+    #if TINYMIND_USE_COS_26_102
+    struct CosValuesTableQ26_102
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_26_102
+    #if TINYMIND_USE_COS_27_101
+    struct CosValuesTableQ27_101
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_27_101
+    #if TINYMIND_USE_COS_28_100
+    struct CosValuesTableQ28_100
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_28_100
+    #if TINYMIND_USE_COS_29_99
+    struct CosValuesTableQ29_99
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_29_99
+    #if TINYMIND_USE_COS_30_98
+    struct CosValuesTableQ30_98
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_30_98
+    #if TINYMIND_USE_COS_31_97
+    struct CosValuesTableQ31_97
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_31_97
+    #if TINYMIND_USE_COS_32_96
+    struct CosValuesTableQ32_96
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_32_96
+    #if TINYMIND_USE_COS_33_95
+    struct CosValuesTableQ33_95
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_33_95
+    #if TINYMIND_USE_COS_34_94
+    struct CosValuesTableQ34_94
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_34_94
+    #if TINYMIND_USE_COS_35_93
+    struct CosValuesTableQ35_93
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_35_93
+    #if TINYMIND_USE_COS_36_92
+    struct CosValuesTableQ36_92
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_36_92
+    #if TINYMIND_USE_COS_37_91
+    struct CosValuesTableQ37_91
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_37_91
+    #if TINYMIND_USE_COS_38_90
+    struct CosValuesTableQ38_90
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_38_90
+    #if TINYMIND_USE_COS_39_89
+    struct CosValuesTableQ39_89
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_39_89
+    #if TINYMIND_USE_COS_40_88
+    struct CosValuesTableQ40_88
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_40_88
+    #if TINYMIND_USE_COS_41_87
+    struct CosValuesTableQ41_87
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_41_87
+    #if TINYMIND_USE_COS_42_86
+    struct CosValuesTableQ42_86
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_42_86
+    #if TINYMIND_USE_COS_43_85
+    struct CosValuesTableQ43_85
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_43_85
+    #if TINYMIND_USE_COS_44_84
+    struct CosValuesTableQ44_84
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_44_84
+    #if TINYMIND_USE_COS_45_83
+    struct CosValuesTableQ45_83
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_45_83
+    #if TINYMIND_USE_COS_46_82
+    struct CosValuesTableQ46_82
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_46_82
+    #if TINYMIND_USE_COS_47_81
+    struct CosValuesTableQ47_81
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_47_81
+    #if TINYMIND_USE_COS_48_80
+    struct CosValuesTableQ48_80
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_48_80
+    #if TINYMIND_USE_COS_49_79
+    struct CosValuesTableQ49_79
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_49_79
+    #if TINYMIND_USE_COS_50_78
+    struct CosValuesTableQ50_78
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_50_78
+    #if TINYMIND_USE_COS_51_77
+    struct CosValuesTableQ51_77
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_51_77
+    #if TINYMIND_USE_COS_52_76
+    struct CosValuesTableQ52_76
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_52_76
+    #if TINYMIND_USE_COS_53_75
+    struct CosValuesTableQ53_75
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_53_75
+    #if TINYMIND_USE_COS_54_74
+    struct CosValuesTableQ54_74
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_54_74
+    #if TINYMIND_USE_COS_55_73
+    struct CosValuesTableQ55_73
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_55_73
+    #if TINYMIND_USE_COS_56_72
+    struct CosValuesTableQ56_72
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_56_72
+    #if TINYMIND_USE_COS_57_71
+    struct CosValuesTableQ57_71
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_57_71
+    #if TINYMIND_USE_COS_58_70
+    struct CosValuesTableQ58_70
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_58_70
+    #if TINYMIND_USE_COS_59_69
+    struct CosValuesTableQ59_69
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_59_69
+    #if TINYMIND_USE_COS_60_68
+    struct CosValuesTableQ60_68
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_60_68
+    #if TINYMIND_USE_COS_61_67
+    struct CosValuesTableQ61_67
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_61_67
+    #if TINYMIND_USE_COS_62_66
+    struct CosValuesTableQ62_66
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_62_66
+    #if TINYMIND_USE_COS_63_65
+    struct CosValuesTableQ63_65
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_63_65
+    #if TINYMIND_USE_COS_64_64
+    struct CosValuesTableQ64_64
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_64_64
+    #if TINYMIND_USE_COS_65_63
+    struct CosValuesTableQ65_63
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_65_63
+    #if TINYMIND_USE_COS_66_62
+    struct CosValuesTableQ66_62
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_66_62
+    #if TINYMIND_USE_COS_67_61
+    struct CosValuesTableQ67_61
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_67_61
+    #if TINYMIND_USE_COS_68_60
+    struct CosValuesTableQ68_60
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_68_60
+    #if TINYMIND_USE_COS_69_59
+    struct CosValuesTableQ69_59
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_69_59
+    #if TINYMIND_USE_COS_70_58
+    struct CosValuesTableQ70_58
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_70_58
+    #if TINYMIND_USE_COS_71_57
+    struct CosValuesTableQ71_57
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_71_57
+    #if TINYMIND_USE_COS_72_56
+    struct CosValuesTableQ72_56
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_72_56
+    #if TINYMIND_USE_COS_73_55
+    struct CosValuesTableQ73_55
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_73_55
+    #if TINYMIND_USE_COS_74_54
+    struct CosValuesTableQ74_54
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_74_54
+    #if TINYMIND_USE_COS_75_53
+    struct CosValuesTableQ75_53
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_75_53
+    #if TINYMIND_USE_COS_76_52
+    struct CosValuesTableQ76_52
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_76_52
+    #if TINYMIND_USE_COS_77_51
+    struct CosValuesTableQ77_51
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_77_51
+    #if TINYMIND_USE_COS_78_50
+    struct CosValuesTableQ78_50
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_78_50
+    #if TINYMIND_USE_COS_79_49
+    struct CosValuesTableQ79_49
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_79_49
+    #if TINYMIND_USE_COS_80_48
+    struct CosValuesTableQ80_48
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_80_48
+    #if TINYMIND_USE_COS_81_47
+    struct CosValuesTableQ81_47
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_81_47
+    #if TINYMIND_USE_COS_82_46
+    struct CosValuesTableQ82_46
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_82_46
+    #if TINYMIND_USE_COS_83_45
+    struct CosValuesTableQ83_45
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_83_45
+    #if TINYMIND_USE_COS_84_44
+    struct CosValuesTableQ84_44
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_84_44
+    #if TINYMIND_USE_COS_85_43
+    struct CosValuesTableQ85_43
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_85_43
+    #if TINYMIND_USE_COS_86_42
+    struct CosValuesTableQ86_42
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_86_42
+    #if TINYMIND_USE_COS_87_41
+    struct CosValuesTableQ87_41
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_87_41
+    #if TINYMIND_USE_COS_88_40
+    struct CosValuesTableQ88_40
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_88_40
+    #if TINYMIND_USE_COS_89_39
+    struct CosValuesTableQ89_39
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_89_39
+    #if TINYMIND_USE_COS_90_38
+    struct CosValuesTableQ90_38
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_90_38
+    #if TINYMIND_USE_COS_91_37
+    struct CosValuesTableQ91_37
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_91_37
+    #if TINYMIND_USE_COS_92_36
+    struct CosValuesTableQ92_36
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_92_36
+    #if TINYMIND_USE_COS_93_35
+    struct CosValuesTableQ93_35
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_93_35
+    #if TINYMIND_USE_COS_94_34
+    struct CosValuesTableQ94_34
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_94_34
+    #if TINYMIND_USE_COS_95_33
+    struct CosValuesTableQ95_33
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_95_33
+    #if TINYMIND_USE_COS_96_32
+    struct CosValuesTableQ96_32
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_96_32
+    #if TINYMIND_USE_COS_97_31
+    struct CosValuesTableQ97_31
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_97_31
+    #if TINYMIND_USE_COS_98_30
+    struct CosValuesTableQ98_30
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_98_30
+    #if TINYMIND_USE_COS_99_29
+    struct CosValuesTableQ99_29
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_99_29
+    #if TINYMIND_USE_COS_100_28
+    struct CosValuesTableQ100_28
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_100_28
+    #if TINYMIND_USE_COS_101_27
+    struct CosValuesTableQ101_27
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_101_27
+    #if TINYMIND_USE_COS_102_26
+    struct CosValuesTableQ102_26
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_102_26
+    #if TINYMIND_USE_COS_103_25
+    struct CosValuesTableQ103_25
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_103_25
+    #if TINYMIND_USE_COS_104_24
+    struct CosValuesTableQ104_24
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_104_24
+    #if TINYMIND_USE_COS_105_23
+    struct CosValuesTableQ105_23
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_105_23
+    #if TINYMIND_USE_COS_106_22
+    struct CosValuesTableQ106_22
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_106_22
+    #if TINYMIND_USE_COS_107_21
+    struct CosValuesTableQ107_21
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_107_21
+    #if TINYMIND_USE_COS_108_20
+    struct CosValuesTableQ108_20
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_108_20
+    #if TINYMIND_USE_COS_109_19
+    struct CosValuesTableQ109_19
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_109_19
+    #if TINYMIND_USE_COS_110_18
+    struct CosValuesTableQ110_18
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_110_18
+    #if TINYMIND_USE_COS_111_17
+    struct CosValuesTableQ111_17
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_111_17
+    #if TINYMIND_USE_COS_112_16
+    struct CosValuesTableQ112_16
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_112_16
+    #if TINYMIND_USE_COS_113_15
+    struct CosValuesTableQ113_15
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_113_15
+    #if TINYMIND_USE_COS_114_14
+    struct CosValuesTableQ114_14
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_114_14
+    #if TINYMIND_USE_COS_115_13
+    struct CosValuesTableQ115_13
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_115_13
+    #if TINYMIND_USE_COS_116_12
+    struct CosValuesTableQ116_12
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_116_12
+    #if TINYMIND_USE_COS_117_11
+    struct CosValuesTableQ117_11
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_117_11
+    #if TINYMIND_USE_COS_118_10
+    struct CosValuesTableQ118_10
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_118_10
+    #if TINYMIND_USE_COS_119_9
+    struct CosValuesTableQ119_9
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_119_9
+    #if TINYMIND_USE_COS_120_8
+    struct CosValuesTableQ120_8
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_120_8
+    #if TINYMIND_USE_COS_121_7
+    struct CosValuesTableQ121_7
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_121_7
+    #if TINYMIND_USE_COS_122_6
+    struct CosValuesTableQ122_6
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_122_6
+    #if TINYMIND_USE_COS_123_5
+    struct CosValuesTableQ123_5
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_123_5
+    #if TINYMIND_USE_COS_124_4
+    struct CosValuesTableQ124_4
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_124_4
+    #if TINYMIND_USE_COS_125_3
+    struct CosValuesTableQ125_3
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_125_3
+    #if TINYMIND_USE_COS_126_2
+    struct CosValuesTableQ126_2
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_126_2
+    #if TINYMIND_USE_COS_127_1
+    struct CosValuesTableQ127_1
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_127_1
+}

--- a/cpp/cosValues16Bit.hpp
+++ b/cpp/cosValues16Bit.hpp
@@ -19,27 +19,6 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 * SOFTWARE.
 */
-/**
-* Copyright (c) 2020 Intel Corporation
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
 
 #pragma once
 

--- a/cpp/cosValues16Bit.hpp
+++ b/cpp/cosValues16Bit.hpp
@@ -1,0 +1,139 @@
+/**
+* Copyright (c) 2026 Dan McLeran
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+/**
+* Copyright (c) 2020 Intel Corporation
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#pragma once
+
+#include "activation.hpp"
+
+namespace tinymind {
+    #if TINYMIND_USE_COS_1_15
+    struct CosValuesTableQ1_15
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_1_15
+    #if TINYMIND_USE_COS_2_14
+    struct CosValuesTableQ2_14
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_2_14
+    #if TINYMIND_USE_COS_3_13
+    struct CosValuesTableQ3_13
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_3_13
+    #if TINYMIND_USE_COS_4_12
+    struct CosValuesTableQ4_12
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_4_12
+    #if TINYMIND_USE_COS_5_11
+    struct CosValuesTableQ5_11
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_5_11
+    #if TINYMIND_USE_COS_6_10
+    struct CosValuesTableQ6_10
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_6_10
+    #if TINYMIND_USE_COS_7_9
+    struct CosValuesTableQ7_9
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_7_9
+    #if TINYMIND_USE_COS_8_8
+    struct CosValuesTableQ8_8
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_8_8
+    #if TINYMIND_USE_COS_9_7
+    struct CosValuesTableQ9_7
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_9_7
+    #if TINYMIND_USE_COS_10_6
+    struct CosValuesTableQ10_6
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_10_6
+    #if TINYMIND_USE_COS_11_5
+    struct CosValuesTableQ11_5
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_11_5
+    #if TINYMIND_USE_COS_12_4
+    struct CosValuesTableQ12_4
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_12_4
+    #if TINYMIND_USE_COS_13_3
+    struct CosValuesTableQ13_3
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_13_3
+    #if TINYMIND_USE_COS_14_2
+    struct CosValuesTableQ14_2
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_14_2
+    #if TINYMIND_USE_COS_15_1
+    struct CosValuesTableQ15_1
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_15_1
+}

--- a/cpp/cosValues32Bit.hpp
+++ b/cpp/cosValues32Bit.hpp
@@ -19,27 +19,6 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 * SOFTWARE.
 */
-/**
-* Copyright (c) 2020 Intel Corporation
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
 
 #pragma once
 

--- a/cpp/cosValues32Bit.hpp
+++ b/cpp/cosValues32Bit.hpp
@@ -1,0 +1,235 @@
+/**
+* Copyright (c) 2026 Dan McLeran
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+/**
+* Copyright (c) 2020 Intel Corporation
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#pragma once
+
+#include "activation.hpp"
+
+namespace tinymind {
+    #if TINYMIND_USE_COS_1_31
+    struct CosValuesTableQ1_31
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_1_31
+    #if TINYMIND_USE_COS_2_30
+    struct CosValuesTableQ2_30
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_2_30
+    #if TINYMIND_USE_COS_3_29
+    struct CosValuesTableQ3_29
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_3_29
+    #if TINYMIND_USE_COS_4_28
+    struct CosValuesTableQ4_28
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_4_28
+    #if TINYMIND_USE_COS_5_27
+    struct CosValuesTableQ5_27
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_5_27
+    #if TINYMIND_USE_COS_6_26
+    struct CosValuesTableQ6_26
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_6_26
+    #if TINYMIND_USE_COS_7_25
+    struct CosValuesTableQ7_25
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_7_25
+    #if TINYMIND_USE_COS_8_24
+    struct CosValuesTableQ8_24
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_8_24
+    #if TINYMIND_USE_COS_9_23
+    struct CosValuesTableQ9_23
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_9_23
+    #if TINYMIND_USE_COS_10_22
+    struct CosValuesTableQ10_22
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_10_22
+    #if TINYMIND_USE_COS_11_21
+    struct CosValuesTableQ11_21
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_11_21
+    #if TINYMIND_USE_COS_12_20
+    struct CosValuesTableQ12_20
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_12_20
+    #if TINYMIND_USE_COS_13_19
+    struct CosValuesTableQ13_19
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_13_19
+    #if TINYMIND_USE_COS_14_18
+    struct CosValuesTableQ14_18
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_14_18
+    #if TINYMIND_USE_COS_15_17
+    struct CosValuesTableQ15_17
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_15_17
+    #if TINYMIND_USE_COS_16_16
+    struct CosValuesTableQ16_16
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_16_16
+    #if TINYMIND_USE_COS_17_15
+    struct CosValuesTableQ17_15
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_17_15
+    #if TINYMIND_USE_COS_18_14
+    struct CosValuesTableQ18_14
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_18_14
+    #if TINYMIND_USE_COS_19_13
+    struct CosValuesTableQ19_13
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_19_13
+    #if TINYMIND_USE_COS_20_12
+    struct CosValuesTableQ20_12
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_20_12
+    #if TINYMIND_USE_COS_21_11
+    struct CosValuesTableQ21_11
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_21_11
+    #if TINYMIND_USE_COS_22_10
+    struct CosValuesTableQ22_10
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_22_10
+    #if TINYMIND_USE_COS_23_9
+    struct CosValuesTableQ23_9
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_23_9
+    #if TINYMIND_USE_COS_24_8
+    struct CosValuesTableQ24_8
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_24_8
+    #if TINYMIND_USE_COS_25_7
+    struct CosValuesTableQ25_7
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_25_7
+    #if TINYMIND_USE_COS_26_6
+    struct CosValuesTableQ26_6
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_26_6
+    #if TINYMIND_USE_COS_27_5
+    struct CosValuesTableQ27_5
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_27_5
+    #if TINYMIND_USE_COS_28_4
+    struct CosValuesTableQ28_4
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_28_4
+    #if TINYMIND_USE_COS_29_3
+    struct CosValuesTableQ29_3
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_29_3
+    #if TINYMIND_USE_COS_30_2
+    struct CosValuesTableQ30_2
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_30_2
+    #if TINYMIND_USE_COS_31_1
+    struct CosValuesTableQ31_1
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_31_1
+}

--- a/cpp/cosValues64Bit.hpp
+++ b/cpp/cosValues64Bit.hpp
@@ -19,27 +19,6 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 * SOFTWARE.
 */
-/**
-* Copyright (c) 2020 Intel Corporation
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
 
 #pragma once
 

--- a/cpp/cosValues64Bit.hpp
+++ b/cpp/cosValues64Bit.hpp
@@ -1,0 +1,427 @@
+/**
+* Copyright (c) 2026 Dan McLeran
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+/**
+* Copyright (c) 2020 Intel Corporation
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#pragma once
+
+#include "activation.hpp"
+
+namespace tinymind {
+    #if TINYMIND_USE_COS_1_63
+    struct CosValuesTableQ1_63
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_1_63
+    #if TINYMIND_USE_COS_2_62
+    struct CosValuesTableQ2_62
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_2_62
+    #if TINYMIND_USE_COS_3_61
+    struct CosValuesTableQ3_61
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_3_61
+    #if TINYMIND_USE_COS_4_60
+    struct CosValuesTableQ4_60
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_4_60
+    #if TINYMIND_USE_COS_5_59
+    struct CosValuesTableQ5_59
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_5_59
+    #if TINYMIND_USE_COS_6_58
+    struct CosValuesTableQ6_58
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_6_58
+    #if TINYMIND_USE_COS_7_57
+    struct CosValuesTableQ7_57
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_7_57
+    #if TINYMIND_USE_COS_8_56
+    struct CosValuesTableQ8_56
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_8_56
+    #if TINYMIND_USE_COS_9_55
+    struct CosValuesTableQ9_55
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_9_55
+    #if TINYMIND_USE_COS_10_54
+    struct CosValuesTableQ10_54
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_10_54
+    #if TINYMIND_USE_COS_11_53
+    struct CosValuesTableQ11_53
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_11_53
+    #if TINYMIND_USE_COS_12_52
+    struct CosValuesTableQ12_52
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_12_52
+    #if TINYMIND_USE_COS_13_51
+    struct CosValuesTableQ13_51
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_13_51
+    #if TINYMIND_USE_COS_14_50
+    struct CosValuesTableQ14_50
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_14_50
+    #if TINYMIND_USE_COS_15_49
+    struct CosValuesTableQ15_49
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_15_49
+    #if TINYMIND_USE_COS_16_48
+    struct CosValuesTableQ16_48
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_16_48
+    #if TINYMIND_USE_COS_17_47
+    struct CosValuesTableQ17_47
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_17_47
+    #if TINYMIND_USE_COS_18_46
+    struct CosValuesTableQ18_46
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_18_46
+    #if TINYMIND_USE_COS_19_45
+    struct CosValuesTableQ19_45
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_19_45
+    #if TINYMIND_USE_COS_20_44
+    struct CosValuesTableQ20_44
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_20_44
+    #if TINYMIND_USE_COS_21_43
+    struct CosValuesTableQ21_43
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_21_43
+    #if TINYMIND_USE_COS_22_42
+    struct CosValuesTableQ22_42
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_22_42
+    #if TINYMIND_USE_COS_23_41
+    struct CosValuesTableQ23_41
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_23_41
+    #if TINYMIND_USE_COS_24_40
+    struct CosValuesTableQ24_40
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_24_40
+    #if TINYMIND_USE_COS_25_39
+    struct CosValuesTableQ25_39
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_25_39
+    #if TINYMIND_USE_COS_26_38
+    struct CosValuesTableQ26_38
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_26_38
+    #if TINYMIND_USE_COS_27_37
+    struct CosValuesTableQ27_37
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_27_37
+    #if TINYMIND_USE_COS_28_36
+    struct CosValuesTableQ28_36
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_28_36
+    #if TINYMIND_USE_COS_29_35
+    struct CosValuesTableQ29_35
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_29_35
+    #if TINYMIND_USE_COS_30_34
+    struct CosValuesTableQ30_34
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_30_34
+    #if TINYMIND_USE_COS_31_33
+    struct CosValuesTableQ31_33
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_31_33
+    #if TINYMIND_USE_COS_32_32
+    struct CosValuesTableQ32_32
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_32_32
+    #if TINYMIND_USE_COS_33_31
+    struct CosValuesTableQ33_31
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_33_31
+    #if TINYMIND_USE_COS_34_30
+    struct CosValuesTableQ34_30
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_34_30
+    #if TINYMIND_USE_COS_35_29
+    struct CosValuesTableQ35_29
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_35_29
+    #if TINYMIND_USE_COS_36_28
+    struct CosValuesTableQ36_28
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_36_28
+    #if TINYMIND_USE_COS_37_27
+    struct CosValuesTableQ37_27
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_37_27
+    #if TINYMIND_USE_COS_38_26
+    struct CosValuesTableQ38_26
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_38_26
+    #if TINYMIND_USE_COS_39_25
+    struct CosValuesTableQ39_25
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_39_25
+    #if TINYMIND_USE_COS_40_24
+    struct CosValuesTableQ40_24
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_40_24
+    #if TINYMIND_USE_COS_41_23
+    struct CosValuesTableQ41_23
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_41_23
+    #if TINYMIND_USE_COS_42_22
+    struct CosValuesTableQ42_22
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_42_22
+    #if TINYMIND_USE_COS_43_21
+    struct CosValuesTableQ43_21
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_43_21
+    #if TINYMIND_USE_COS_44_20
+    struct CosValuesTableQ44_20
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_44_20
+    #if TINYMIND_USE_COS_45_19
+    struct CosValuesTableQ45_19
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_45_19
+    #if TINYMIND_USE_COS_46_18
+    struct CosValuesTableQ46_18
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_46_18
+    #if TINYMIND_USE_COS_47_17
+    struct CosValuesTableQ47_17
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_47_17
+    #if TINYMIND_USE_COS_48_16
+    struct CosValuesTableQ48_16
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_48_16
+    #if TINYMIND_USE_COS_49_15
+    struct CosValuesTableQ49_15
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_49_15
+    #if TINYMIND_USE_COS_50_14
+    struct CosValuesTableQ50_14
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_50_14
+    #if TINYMIND_USE_COS_51_13
+    struct CosValuesTableQ51_13
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_51_13
+    #if TINYMIND_USE_COS_52_12
+    struct CosValuesTableQ52_12
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_52_12
+    #if TINYMIND_USE_COS_53_11
+    struct CosValuesTableQ53_11
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_53_11
+    #if TINYMIND_USE_COS_54_10
+    struct CosValuesTableQ54_10
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_54_10
+    #if TINYMIND_USE_COS_55_9
+    struct CosValuesTableQ55_9
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_55_9
+    #if TINYMIND_USE_COS_56_8
+    struct CosValuesTableQ56_8
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_56_8
+    #if TINYMIND_USE_COS_57_7
+    struct CosValuesTableQ57_7
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_57_7
+    #if TINYMIND_USE_COS_58_6
+    struct CosValuesTableQ58_6
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_58_6
+    #if TINYMIND_USE_COS_59_5
+    struct CosValuesTableQ59_5
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_59_5
+    #if TINYMIND_USE_COS_60_4
+    struct CosValuesTableQ60_4
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_60_4
+    #if TINYMIND_USE_COS_61_3
+    struct CosValuesTableQ61_3
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_61_3
+    #if TINYMIND_USE_COS_62_2
+    struct CosValuesTableQ62_2
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_62_2
+    #if TINYMIND_USE_COS_63_1
+    struct CosValuesTableQ63_1
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_63_1
+}

--- a/cpp/cosValues8Bit.hpp
+++ b/cpp/cosValues8Bit.hpp
@@ -1,0 +1,91 @@
+/**
+* Copyright (c) 2026 Dan McLeran
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+/**
+* Copyright (c) 2020 Intel Corporation
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#pragma once
+
+#include "activation.hpp"
+
+namespace tinymind {
+    #if TINYMIND_USE_COS_1_7
+    struct CosValuesTableQ1_7
+    {
+        static const uint8_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_1_7
+    #if TINYMIND_USE_COS_2_6
+    struct CosValuesTableQ2_6
+    {
+        static const uint8_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_2_6
+    #if TINYMIND_USE_COS_3_5
+    struct CosValuesTableQ3_5
+    {
+        static const uint8_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_3_5
+    #if TINYMIND_USE_COS_4_4
+    struct CosValuesTableQ4_4
+    {
+        static const uint8_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_4_4
+    #if TINYMIND_USE_COS_5_3
+    struct CosValuesTableQ5_3
+    {
+        static const uint8_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_5_3
+    #if TINYMIND_USE_COS_6_2
+    struct CosValuesTableQ6_2
+    {
+        static const uint8_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_6_2
+    #if TINYMIND_USE_COS_7_1
+    struct CosValuesTableQ7_1
+    {
+        static const uint8_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_COS_7_1
+}

--- a/cpp/cosValues8Bit.hpp
+++ b/cpp/cosValues8Bit.hpp
@@ -19,27 +19,6 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 * SOFTWARE.
 */
-/**
-* Copyright (c) 2020 Intel Corporation
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
 
 #pragma once
 

--- a/cpp/exp.hpp
+++ b/cpp/exp.hpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023 Dan McLeran
+* Copyright (c) 2026 Dan McLeran
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/cpp/expValues128Bit.hpp
+++ b/cpp/expValues128Bit.hpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023 Dan McLeran
+* Copyright (c) 2026 Dan McLeran
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/cpp/expValues16Bit.hpp
+++ b/cpp/expValues16Bit.hpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023 Dan McLeran
+* Copyright (c) 2026 Dan McLeran
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/cpp/expValues32Bit.hpp
+++ b/cpp/expValues32Bit.hpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023 Dan McLeran
+* Copyright (c) 2026 Dan McLeran
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/cpp/expValues64Bit.hpp
+++ b/cpp/expValues64Bit.hpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023 Dan McLeran
+* Copyright (c) 2026 Dan McLeran
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/cpp/expValues8Bit.hpp
+++ b/cpp/expValues8Bit.hpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023 Dan McLeran
+* Copyright (c) 2026 Dan McLeran
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/cpp/fft1d.hpp
+++ b/cpp/fft1d.hpp
@@ -141,48 +141,15 @@ namespace tinymind {
          */
         void forward(ValueType* real, ValueType* imag) const
         {
-            bitReversalPermute(real, imag);
-
-            size_t halfSize = 1;
-            for (size_t stage = 0; stage < NumStages; ++stage)
-            {
-                const size_t fullSize = halfSize << 1;
-                const size_t twiddleStride = HalfLength / halfSize;
-
-                for (size_t group = 0; group < N; group += fullSize)
-                {
-                    for (size_t pair = 0; pair < halfSize; ++pair)
-                    {
-                        const size_t twiddleIdx = pair * twiddleStride;
-                        const ValueType wCos = mTwiddleCos[twiddleIdx];
-                        const ValueType wSin = mTwiddleSin[twiddleIdx];
-
-                        const size_t top = group + pair;
-                        const size_t bot = top + halfSize;
-
-                        // Complex multiply: W * x[bot]
-                        const ValueType tReal = wCos * real[bot] - wSin * imag[bot];
-                        const ValueType tImag = wCos * imag[bot] + wSin * real[bot];
-
-                        // Scaled butterfly: divide by 2 each stage to prevent overflow
-                        const ValueType topReal = real[top];
-                        const ValueType topImag = imag[top];
-                        real[top] = (topReal + tReal) / 2;
-                        imag[top] = (topImag + tImag) / 2;
-                        real[bot] = (topReal - tReal) / 2;
-                        imag[bot] = (topImag - tImag) / 2;
-                    }
-                }
-                halfSize = fullSize;
-            }
+            forwardImpl(real, imag, true);
         }
 
         /**
          * Inverse FFT: frequency domain -> time domain (in-place).
          *
-         * Conjugates input, runs forward FFT, then conjugates output.
-         * The forward FFT already applies 1/N scaling through its
-         * scaled butterfly stages, so no additional division is needed.
+         * Uses the conjugate trick: IFFT(X) = conj(DFT(conj(X))).
+         * The unscaled DFT is used internally so that forward (which
+         * scales by 1/N) and inverse are true inverses of each other.
          */
         void inverse(ValueType* real, ValueType* imag) const
         {
@@ -192,9 +159,10 @@ namespace tinymind {
                 imag[i] = ValueType(0) - imag[i];
             }
 
-            forward(real, imag);
+            // Unscaled DFT so that forward's 1/N and inverse cancel
+            forwardImpl(real, imag, false);
 
-            // Conjugate output (forward already scaled by 1/N)
+            // Conjugate output
             for (size_t i = 0; i < N; ++i)
             {
                 imag[i] = ValueType(0) - imag[i];
@@ -223,6 +191,58 @@ namespace tinymind {
         ValueType mTwiddleSin[HalfLength];
 
         static constexpr detail::BitReversalTable<N, NumStages> sBitRevTable{};
+
+        /**
+         * Core FFT implementation.
+         * @param scale  If true, divide by 2 each stage (forward FFT).
+         *               If false, no scaling (used by inverse FFT).
+         */
+        void forwardImpl(ValueType* real, ValueType* imag, const bool scale) const
+        {
+            bitReversalPermute(real, imag);
+
+            size_t halfSize = 1;
+            for (size_t stage = 0; stage < NumStages; ++stage)
+            {
+                const size_t fullSize = halfSize << 1;
+                const size_t twiddleStride = HalfLength / halfSize;
+
+                for (size_t group = 0; group < N; group += fullSize)
+                {
+                    for (size_t pair = 0; pair < halfSize; ++pair)
+                    {
+                        const size_t twiddleIdx = pair * twiddleStride;
+                        const ValueType wCos = mTwiddleCos[twiddleIdx];
+                        const ValueType wSin = mTwiddleSin[twiddleIdx];
+
+                        const size_t top = group + pair;
+                        const size_t bot = top + halfSize;
+
+                        const ValueType tReal = wCos * real[bot] - wSin * imag[bot];
+                        const ValueType tImag = wCos * imag[bot] + wSin * real[bot];
+
+                        const ValueType topReal = real[top];
+                        const ValueType topImag = imag[top];
+
+                        if (scale)
+                        {
+                            real[top] = (topReal + tReal) / 2;
+                            imag[top] = (topImag + tImag) / 2;
+                            real[bot] = (topReal - tReal) / 2;
+                            imag[bot] = (topImag - tImag) / 2;
+                        }
+                        else
+                        {
+                            real[top] = topReal + tReal;
+                            imag[top] = topImag + tImag;
+                            real[bot] = topReal - tReal;
+                            imag[bot] = topImag - tImag;
+                        }
+                    }
+                }
+                halfSize = fullSize;
+            }
+        }
 
         static void bitReversalPermute(ValueType* real, ValueType* imag)
         {

--- a/cpp/fft1d.hpp
+++ b/cpp/fft1d.hpp
@@ -1,0 +1,248 @@
+/**
+* Copyright (c) 2026 Dan McLeran
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#pragma once
+
+#include <cstddef>
+
+namespace tinymind {
+
+    namespace detail {
+        template<size_t N>
+        struct Log2
+        {
+            static const size_t value = 1 + Log2<N / 2>::value;
+        };
+
+        template<>
+        struct Log2<1>
+        {
+            static const size_t value = 0;
+        };
+
+        template<size_t N, size_t NumStages>
+        struct BitReversalTable
+        {
+            size_t indices[N];
+
+            constexpr BitReversalTable() : indices{}
+            {
+                for (size_t i = 0; i < N; ++i)
+                {
+                    size_t x = i;
+                    size_t result = 0;
+                    for (size_t b = 0; b < NumStages; ++b)
+                    {
+                        result = (result << 1) | (x & 1);
+                        x >>= 1;
+                    }
+                    indices[i] = result;
+                }
+            }
+        };
+    }
+
+    /**
+     * Radix-2 decimation-in-time FFT for power-of-two lengths.
+     *
+     * Designed for embedded signal processing (vibration, audio, IMU).
+     * All dimensions are compile-time template parameters with zero
+     * dynamic allocation. Uses scaled butterfly stages (shift-right
+     * by 1 each stage) to prevent overflow in fixed-point arithmetic.
+     *
+     * For Q-format types, twiddle factors (sin/cos) must be provided
+     * via setTwiddleFactors() since there are no built-in trig
+     * functions for fixed-point. For float/double, twiddle factors
+     * can be computed at runtime with standard math functions.
+     *
+     * Output feeds into any TinyMind network as input:
+     *   FFT1D<Q8_8, 128> fft;
+     *   NeuralNetwork<Q8_8, 64, ...> mlp;  // N/2 magnitude bins
+     *
+     *   fft.forward(real, imag);
+     *   fft.magnitudeSquared(real, imag, magSq);
+     *   mlp.feedForward(magSq);
+     *
+     * @tparam ValueType  Numeric type (QValue or float/double)
+     * @tparam N          FFT length (must be power of two, >= 2)
+     */
+    template<typename ValueType, size_t N>
+    class FFT1D
+    {
+    public:
+        static const size_t Length = N;
+        static const size_t HalfLength = N / 2;
+        static const size_t NumStages = detail::Log2<N>::value;
+
+        FFT1D()
+        {
+            for (size_t i = 0; i < HalfLength; ++i)
+            {
+                mTwiddleCos[i] = ValueType(0);
+                mTwiddleSin[i] = ValueType(0);
+            }
+        }
+
+        /**
+         * Set the twiddle factors (cosine and sine of -2*pi*k/N).
+         *
+         * For float/double, compute with std::cos/std::sin.
+         * For Q-format, pre-compute externally and load here.
+         *
+         * @param cosTable  Array of N/2 cosine values: cos(-2*pi*k/N) for k=0..N/2-1
+         * @param sinTable  Array of N/2 sine values:   sin(-2*pi*k/N) for k=0..N/2-1
+         */
+        void setTwiddleFactors(const ValueType* cosTable, const ValueType* sinTable)
+        {
+            for (size_t k = 0; k < HalfLength; ++k)
+            {
+                mTwiddleCos[k] = cosTable[k];
+                mTwiddleSin[k] = sinTable[k];
+            }
+        }
+
+        /**
+         * Get a twiddle cosine factor.
+         */
+        ValueType getTwiddleCos(const size_t index) const { return mTwiddleCos[index]; }
+
+        /**
+         * Get a twiddle sine factor.
+         */
+        ValueType getTwiddleSin(const size_t index) const { return mTwiddleSin[index]; }
+
+        /**
+         * Forward FFT: time domain -> frequency domain (in-place).
+         *
+         * Uses scaled butterfly: each stage right-shifts results by 1
+         * to prevent fixed-point overflow. Total scaling is 1/N.
+         *
+         * @param real  Array of N real parts (input/output)
+         * @param imag  Array of N imaginary parts (input/output, init to 0 for real signals)
+         */
+        void forward(ValueType* real, ValueType* imag) const
+        {
+            bitReversalPermute(real, imag);
+
+            size_t halfSize = 1;
+            for (size_t stage = 0; stage < NumStages; ++stage)
+            {
+                const size_t fullSize = halfSize << 1;
+                const size_t twiddleStride = HalfLength / halfSize;
+
+                for (size_t group = 0; group < N; group += fullSize)
+                {
+                    for (size_t pair = 0; pair < halfSize; ++pair)
+                    {
+                        const size_t twiddleIdx = pair * twiddleStride;
+                        const ValueType wCos = mTwiddleCos[twiddleIdx];
+                        const ValueType wSin = mTwiddleSin[twiddleIdx];
+
+                        const size_t top = group + pair;
+                        const size_t bot = top + halfSize;
+
+                        // Complex multiply: W * x[bot]
+                        const ValueType tReal = wCos * real[bot] - wSin * imag[bot];
+                        const ValueType tImag = wCos * imag[bot] + wSin * real[bot];
+
+                        // Scaled butterfly: divide by 2 each stage to prevent overflow
+                        const ValueType topReal = real[top];
+                        const ValueType topImag = imag[top];
+                        real[top] = (topReal + tReal) / 2;
+                        imag[top] = (topImag + tImag) / 2;
+                        real[bot] = (topReal - tReal) / 2;
+                        imag[bot] = (topImag - tImag) / 2;
+                    }
+                }
+                halfSize = fullSize;
+            }
+        }
+
+        /**
+         * Inverse FFT: frequency domain -> time domain (in-place).
+         *
+         * Conjugates input, runs forward FFT, then conjugates output.
+         * The forward FFT already applies 1/N scaling through its
+         * scaled butterfly stages, so no additional division is needed.
+         */
+        void inverse(ValueType* real, ValueType* imag) const
+        {
+            // Conjugate
+            for (size_t i = 0; i < N; ++i)
+            {
+                imag[i] = ValueType(0) - imag[i];
+            }
+
+            forward(real, imag);
+
+            // Conjugate output (forward already scaled by 1/N)
+            for (size_t i = 0; i < N; ++i)
+            {
+                imag[i] = ValueType(0) - imag[i];
+            }
+        }
+
+        /**
+         * Compute magnitude squared of each frequency bin.
+         * Avoids sqrt which is expensive/unavailable in fixed-point.
+         *
+         * @param real      Input real parts (N elements)
+         * @param imag      Input imaginary parts (N elements)
+         * @param magSq     Output magnitude squared (N elements)
+         */
+        static void magnitudeSquared(const ValueType* real, const ValueType* imag,
+                                     ValueType* magSq)
+        {
+            for (size_t i = 0; i < N; ++i)
+            {
+                magSq[i] = real[i] * real[i] + imag[i] * imag[i];
+            }
+        }
+
+    private:
+        ValueType mTwiddleCos[HalfLength];
+        ValueType mTwiddleSin[HalfLength];
+
+        static constexpr detail::BitReversalTable<N, NumStages> sBitRevTable{};
+
+        static void bitReversalPermute(ValueType* real, ValueType* imag)
+        {
+            for (size_t i = 0; i < N; ++i)
+            {
+                const size_t j = sBitRevTable.indices[i];
+                if (i < j)
+                {
+                    ValueType tmp = real[i];
+                    real[i] = real[j];
+                    real[j] = tmp;
+
+                    tmp = imag[i];
+                    imag[i] = imag[j];
+                    imag[j] = tmp;
+                }
+            }
+        }
+
+        static_assert((N & (N - 1)) == 0, "FFT length must be a power of two.");
+        static_assert(N >= 2, "FFT length must be at least 2.");
+    };
+}

--- a/cpp/log.hpp
+++ b/cpp/log.hpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023 Dan McLeran
+* Copyright (c) 2026 Dan McLeran
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/cpp/logValues128Bit.hpp
+++ b/cpp/logValues128Bit.hpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023 Dan McLeran
+* Copyright (c) 2026 Dan McLeran
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/cpp/logValues16Bit.hpp
+++ b/cpp/logValues16Bit.hpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023 Dan McLeran
+* Copyright (c) 2026 Dan McLeran
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/cpp/logValues32Bit.hpp
+++ b/cpp/logValues32Bit.hpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023 Dan McLeran
+* Copyright (c) 2026 Dan McLeran
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/cpp/logValues64Bit.hpp
+++ b/cpp/logValues64Bit.hpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023 Dan McLeran
+* Copyright (c) 2026 Dan McLeran
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/cpp/logValues8Bit.hpp
+++ b/cpp/logValues8Bit.hpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023 Dan McLeran
+* Copyright (c) 2026 Dan McLeran
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/cpp/sigmoid.hpp
+++ b/cpp/sigmoid.hpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023 Dan McLeran
+* Copyright (c) 2026 Dan McLeran
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/cpp/sigmoidValues128Bit.hpp
+++ b/cpp/sigmoidValues128Bit.hpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023 Dan McLeran
+* Copyright (c) 2026 Dan McLeran
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/cpp/sigmoidValues16Bit.hpp
+++ b/cpp/sigmoidValues16Bit.hpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023 Dan McLeran
+* Copyright (c) 2026 Dan McLeran
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/cpp/sigmoidValues32Bit.hpp
+++ b/cpp/sigmoidValues32Bit.hpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023 Dan McLeran
+* Copyright (c) 2026 Dan McLeran
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/cpp/sigmoidValues64Bit.hpp
+++ b/cpp/sigmoidValues64Bit.hpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023 Dan McLeran
+* Copyright (c) 2026 Dan McLeran
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/cpp/sigmoidValues8Bit.hpp
+++ b/cpp/sigmoidValues8Bit.hpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023 Dan McLeran
+* Copyright (c) 2026 Dan McLeran
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/cpp/sin.hpp
+++ b/cpp/sin.hpp
@@ -1,0 +1,2009 @@
+/**
+* Copyright (c) 2026 Dan McLeran
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+/**
+* Copyright (c) 2020 Intel Corporation
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#pragma once
+
+#include "activation.hpp"
+
+#include "sinValues8Bit.hpp"
+#include "sinValues16Bit.hpp"
+#include "sinValues32Bit.hpp"
+#include "sinValues64Bit.hpp"
+#include "sinValues128Bit.hpp"
+
+namespace tinymind {
+    template<unsigned FixedBits, unsigned FracBits, bool IsSigned>
+    struct SinTableValueSize
+    {
+    };
+
+    #if TINYMIND_USE_SIN_1_7
+    template<>
+    struct SinTableValueSize<1, 7, true>
+    {
+        typedef SinValuesTableQ1_7 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_1_7
+
+    #if TINYMIND_USE_SIN_2_6
+    template<>
+    struct SinTableValueSize<2, 6, true>
+    {
+        typedef SinValuesTableQ2_6 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_2_6
+
+    #if TINYMIND_USE_SIN_3_5
+    template<>
+    struct SinTableValueSize<3, 5, true>
+    {
+        typedef SinValuesTableQ3_5 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_3_5
+
+    #if TINYMIND_USE_SIN_4_4
+    template<>
+    struct SinTableValueSize<4, 4, true>
+    {
+        typedef SinValuesTableQ4_4 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_4_4
+
+    #if TINYMIND_USE_SIN_5_3
+    template<>
+    struct SinTableValueSize<5, 3, true>
+    {
+        typedef SinValuesTableQ5_3 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_5_3
+
+    #if TINYMIND_USE_SIN_6_2
+    template<>
+    struct SinTableValueSize<6, 2, true>
+    {
+        typedef SinValuesTableQ6_2 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_6_2
+
+    #if TINYMIND_USE_SIN_7_1
+    template<>
+    struct SinTableValueSize<7, 1, true>
+    {
+        typedef SinValuesTableQ7_1 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_7_1
+
+    #if TINYMIND_USE_SIN_1_15
+    template<>
+    struct SinTableValueSize<1, 15, true>
+    {
+        typedef SinValuesTableQ1_15 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_1_15
+
+    #if TINYMIND_USE_SIN_2_14
+    template<>
+    struct SinTableValueSize<2, 14, true>
+    {
+        typedef SinValuesTableQ2_14 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_2_14
+
+    #if TINYMIND_USE_SIN_3_13
+    template<>
+    struct SinTableValueSize<3, 13, true>
+    {
+        typedef SinValuesTableQ3_13 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_3_13
+
+    #if TINYMIND_USE_SIN_4_12
+    template<>
+    struct SinTableValueSize<4, 12, true>
+    {
+        typedef SinValuesTableQ4_12 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_4_12
+
+    #if TINYMIND_USE_SIN_5_11
+    template<>
+    struct SinTableValueSize<5, 11, true>
+    {
+        typedef SinValuesTableQ5_11 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_5_11
+
+    #if TINYMIND_USE_SIN_6_10
+    template<>
+    struct SinTableValueSize<6, 10, true>
+    {
+        typedef SinValuesTableQ6_10 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_6_10
+
+    #if TINYMIND_USE_SIN_7_9
+    template<>
+    struct SinTableValueSize<7, 9, true>
+    {
+        typedef SinValuesTableQ7_9 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_7_9
+
+    #if TINYMIND_USE_SIN_8_8
+    template<>
+    struct SinTableValueSize<8, 8, true>
+    {
+        typedef SinValuesTableQ8_8 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_8_8
+
+    #if TINYMIND_USE_SIN_9_7
+    template<>
+    struct SinTableValueSize<9, 7, true>
+    {
+        typedef SinValuesTableQ9_7 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_9_7
+
+    #if TINYMIND_USE_SIN_10_6
+    template<>
+    struct SinTableValueSize<10, 6, true>
+    {
+        typedef SinValuesTableQ10_6 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_10_6
+
+    #if TINYMIND_USE_SIN_11_5
+    template<>
+    struct SinTableValueSize<11, 5, true>
+    {
+        typedef SinValuesTableQ11_5 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_11_5
+
+    #if TINYMIND_USE_SIN_12_4
+    template<>
+    struct SinTableValueSize<12, 4, true>
+    {
+        typedef SinValuesTableQ12_4 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_12_4
+
+    #if TINYMIND_USE_SIN_13_3
+    template<>
+    struct SinTableValueSize<13, 3, true>
+    {
+        typedef SinValuesTableQ13_3 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_13_3
+
+    #if TINYMIND_USE_SIN_14_2
+    template<>
+    struct SinTableValueSize<14, 2, true>
+    {
+        typedef SinValuesTableQ14_2 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_14_2
+
+    #if TINYMIND_USE_SIN_15_1
+    template<>
+    struct SinTableValueSize<15, 1, true>
+    {
+        typedef SinValuesTableQ15_1 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_15_1
+
+    #if TINYMIND_USE_SIN_1_31
+    template<>
+    struct SinTableValueSize<1, 31, true>
+    {
+        typedef SinValuesTableQ1_31 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_1_31
+
+    #if TINYMIND_USE_SIN_2_30
+    template<>
+    struct SinTableValueSize<2, 30, true>
+    {
+        typedef SinValuesTableQ2_30 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_2_30
+
+    #if TINYMIND_USE_SIN_3_29
+    template<>
+    struct SinTableValueSize<3, 29, true>
+    {
+        typedef SinValuesTableQ3_29 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_3_29
+
+    #if TINYMIND_USE_SIN_4_28
+    template<>
+    struct SinTableValueSize<4, 28, true>
+    {
+        typedef SinValuesTableQ4_28 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_4_28
+
+    #if TINYMIND_USE_SIN_5_27
+    template<>
+    struct SinTableValueSize<5, 27, true>
+    {
+        typedef SinValuesTableQ5_27 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_5_27
+
+    #if TINYMIND_USE_SIN_6_26
+    template<>
+    struct SinTableValueSize<6, 26, true>
+    {
+        typedef SinValuesTableQ6_26 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_6_26
+
+    #if TINYMIND_USE_SIN_7_25
+    template<>
+    struct SinTableValueSize<7, 25, true>
+    {
+        typedef SinValuesTableQ7_25 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_7_25
+
+    #if TINYMIND_USE_SIN_8_24
+    template<>
+    struct SinTableValueSize<8, 24, true>
+    {
+        typedef SinValuesTableQ8_24 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_8_24
+
+    #if TINYMIND_USE_SIN_9_23
+    template<>
+    struct SinTableValueSize<9, 23, true>
+    {
+        typedef SinValuesTableQ9_23 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_9_23
+
+    #if TINYMIND_USE_SIN_10_22
+    template<>
+    struct SinTableValueSize<10, 22, true>
+    {
+        typedef SinValuesTableQ10_22 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_10_22
+
+    #if TINYMIND_USE_SIN_11_21
+    template<>
+    struct SinTableValueSize<11, 21, true>
+    {
+        typedef SinValuesTableQ11_21 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_11_21
+
+    #if TINYMIND_USE_SIN_12_20
+    template<>
+    struct SinTableValueSize<12, 20, true>
+    {
+        typedef SinValuesTableQ12_20 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_12_20
+
+    #if TINYMIND_USE_SIN_13_19
+    template<>
+    struct SinTableValueSize<13, 19, true>
+    {
+        typedef SinValuesTableQ13_19 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_13_19
+
+    #if TINYMIND_USE_SIN_14_18
+    template<>
+    struct SinTableValueSize<14, 18, true>
+    {
+        typedef SinValuesTableQ14_18 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_14_18
+
+    #if TINYMIND_USE_SIN_15_17
+    template<>
+    struct SinTableValueSize<15, 17, true>
+    {
+        typedef SinValuesTableQ15_17 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_15_17
+
+    #if TINYMIND_USE_SIN_16_16
+    template<>
+    struct SinTableValueSize<16, 16, true>
+    {
+        typedef SinValuesTableQ16_16 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_16_16
+
+    #if TINYMIND_USE_SIN_17_15
+    template<>
+    struct SinTableValueSize<17, 15, true>
+    {
+        typedef SinValuesTableQ17_15 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_17_15
+
+    #if TINYMIND_USE_SIN_18_14
+    template<>
+    struct SinTableValueSize<18, 14, true>
+    {
+        typedef SinValuesTableQ18_14 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_18_14
+
+    #if TINYMIND_USE_SIN_19_13
+    template<>
+    struct SinTableValueSize<19, 13, true>
+    {
+        typedef SinValuesTableQ19_13 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_19_13
+
+    #if TINYMIND_USE_SIN_20_12
+    template<>
+    struct SinTableValueSize<20, 12, true>
+    {
+        typedef SinValuesTableQ20_12 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_20_12
+
+    #if TINYMIND_USE_SIN_21_11
+    template<>
+    struct SinTableValueSize<21, 11, true>
+    {
+        typedef SinValuesTableQ21_11 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_21_11
+
+    #if TINYMIND_USE_SIN_22_10
+    template<>
+    struct SinTableValueSize<22, 10, true>
+    {
+        typedef SinValuesTableQ22_10 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_22_10
+
+    #if TINYMIND_USE_SIN_23_9
+    template<>
+    struct SinTableValueSize<23, 9, true>
+    {
+        typedef SinValuesTableQ23_9 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_23_9
+
+    #if TINYMIND_USE_SIN_24_8
+    template<>
+    struct SinTableValueSize<24, 8, true>
+    {
+        typedef SinValuesTableQ24_8 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_24_8
+
+    #if TINYMIND_USE_SIN_25_7
+    template<>
+    struct SinTableValueSize<25, 7, true>
+    {
+        typedef SinValuesTableQ25_7 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_25_7
+
+    #if TINYMIND_USE_SIN_26_6
+    template<>
+    struct SinTableValueSize<26, 6, true>
+    {
+        typedef SinValuesTableQ26_6 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_26_6
+
+    #if TINYMIND_USE_SIN_27_5
+    template<>
+    struct SinTableValueSize<27, 5, true>
+    {
+        typedef SinValuesTableQ27_5 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_27_5
+
+    #if TINYMIND_USE_SIN_28_4
+    template<>
+    struct SinTableValueSize<28, 4, true>
+    {
+        typedef SinValuesTableQ28_4 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_28_4
+
+    #if TINYMIND_USE_SIN_29_3
+    template<>
+    struct SinTableValueSize<29, 3, true>
+    {
+        typedef SinValuesTableQ29_3 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_29_3
+
+    #if TINYMIND_USE_SIN_30_2
+    template<>
+    struct SinTableValueSize<30, 2, true>
+    {
+        typedef SinValuesTableQ30_2 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_30_2
+
+    #if TINYMIND_USE_SIN_31_1
+    template<>
+    struct SinTableValueSize<31, 1, true>
+    {
+        typedef SinValuesTableQ31_1 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_31_1
+
+    #if TINYMIND_USE_SIN_1_63
+    template<>
+    struct SinTableValueSize<1, 63, true>
+    {
+        typedef SinValuesTableQ1_63 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_1_63
+
+    #if TINYMIND_USE_SIN_2_62
+    template<>
+    struct SinTableValueSize<2, 62, true>
+    {
+        typedef SinValuesTableQ2_62 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_2_62
+
+    #if TINYMIND_USE_SIN_3_61
+    template<>
+    struct SinTableValueSize<3, 61, true>
+    {
+        typedef SinValuesTableQ3_61 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_3_61
+
+    #if TINYMIND_USE_SIN_4_60
+    template<>
+    struct SinTableValueSize<4, 60, true>
+    {
+        typedef SinValuesTableQ4_60 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_4_60
+
+    #if TINYMIND_USE_SIN_5_59
+    template<>
+    struct SinTableValueSize<5, 59, true>
+    {
+        typedef SinValuesTableQ5_59 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_5_59
+
+    #if TINYMIND_USE_SIN_6_58
+    template<>
+    struct SinTableValueSize<6, 58, true>
+    {
+        typedef SinValuesTableQ6_58 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_6_58
+
+    #if TINYMIND_USE_SIN_7_57
+    template<>
+    struct SinTableValueSize<7, 57, true>
+    {
+        typedef SinValuesTableQ7_57 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_7_57
+
+    #if TINYMIND_USE_SIN_8_56
+    template<>
+    struct SinTableValueSize<8, 56, true>
+    {
+        typedef SinValuesTableQ8_56 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_8_56
+
+    #if TINYMIND_USE_SIN_9_55
+    template<>
+    struct SinTableValueSize<9, 55, true>
+    {
+        typedef SinValuesTableQ9_55 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_9_55
+
+    #if TINYMIND_USE_SIN_10_54
+    template<>
+    struct SinTableValueSize<10, 54, true>
+    {
+        typedef SinValuesTableQ10_54 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_10_54
+
+    #if TINYMIND_USE_SIN_11_53
+    template<>
+    struct SinTableValueSize<11, 53, true>
+    {
+        typedef SinValuesTableQ11_53 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_11_53
+
+    #if TINYMIND_USE_SIN_12_52
+    template<>
+    struct SinTableValueSize<12, 52, true>
+    {
+        typedef SinValuesTableQ12_52 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_12_52
+
+    #if TINYMIND_USE_SIN_13_51
+    template<>
+    struct SinTableValueSize<13, 51, true>
+    {
+        typedef SinValuesTableQ13_51 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_13_51
+
+    #if TINYMIND_USE_SIN_14_50
+    template<>
+    struct SinTableValueSize<14, 50, true>
+    {
+        typedef SinValuesTableQ14_50 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_14_50
+
+    #if TINYMIND_USE_SIN_15_49
+    template<>
+    struct SinTableValueSize<15, 49, true>
+    {
+        typedef SinValuesTableQ15_49 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_15_49
+
+    #if TINYMIND_USE_SIN_16_48
+    template<>
+    struct SinTableValueSize<16, 48, true>
+    {
+        typedef SinValuesTableQ16_48 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_16_48
+
+    #if TINYMIND_USE_SIN_17_47
+    template<>
+    struct SinTableValueSize<17, 47, true>
+    {
+        typedef SinValuesTableQ17_47 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_17_47
+
+    #if TINYMIND_USE_SIN_18_46
+    template<>
+    struct SinTableValueSize<18, 46, true>
+    {
+        typedef SinValuesTableQ18_46 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_18_46
+
+    #if TINYMIND_USE_SIN_19_45
+    template<>
+    struct SinTableValueSize<19, 45, true>
+    {
+        typedef SinValuesTableQ19_45 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_19_45
+
+    #if TINYMIND_USE_SIN_20_44
+    template<>
+    struct SinTableValueSize<20, 44, true>
+    {
+        typedef SinValuesTableQ20_44 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_20_44
+
+    #if TINYMIND_USE_SIN_21_43
+    template<>
+    struct SinTableValueSize<21, 43, true>
+    {
+        typedef SinValuesTableQ21_43 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_21_43
+
+    #if TINYMIND_USE_SIN_22_42
+    template<>
+    struct SinTableValueSize<22, 42, true>
+    {
+        typedef SinValuesTableQ22_42 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_22_42
+
+    #if TINYMIND_USE_SIN_23_41
+    template<>
+    struct SinTableValueSize<23, 41, true>
+    {
+        typedef SinValuesTableQ23_41 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_23_41
+
+    #if TINYMIND_USE_SIN_24_40
+    template<>
+    struct SinTableValueSize<24, 40, true>
+    {
+        typedef SinValuesTableQ24_40 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_24_40
+
+    #if TINYMIND_USE_SIN_25_39
+    template<>
+    struct SinTableValueSize<25, 39, true>
+    {
+        typedef SinValuesTableQ25_39 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_25_39
+
+    #if TINYMIND_USE_SIN_26_38
+    template<>
+    struct SinTableValueSize<26, 38, true>
+    {
+        typedef SinValuesTableQ26_38 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_26_38
+
+    #if TINYMIND_USE_SIN_27_37
+    template<>
+    struct SinTableValueSize<27, 37, true>
+    {
+        typedef SinValuesTableQ27_37 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_27_37
+
+    #if TINYMIND_USE_SIN_28_36
+    template<>
+    struct SinTableValueSize<28, 36, true>
+    {
+        typedef SinValuesTableQ28_36 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_28_36
+
+    #if TINYMIND_USE_SIN_29_35
+    template<>
+    struct SinTableValueSize<29, 35, true>
+    {
+        typedef SinValuesTableQ29_35 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_29_35
+
+    #if TINYMIND_USE_SIN_30_34
+    template<>
+    struct SinTableValueSize<30, 34, true>
+    {
+        typedef SinValuesTableQ30_34 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_30_34
+
+    #if TINYMIND_USE_SIN_31_33
+    template<>
+    struct SinTableValueSize<31, 33, true>
+    {
+        typedef SinValuesTableQ31_33 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_31_33
+
+    #if TINYMIND_USE_SIN_32_32
+    template<>
+    struct SinTableValueSize<32, 32, true>
+    {
+        typedef SinValuesTableQ32_32 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_32_32
+
+    #if TINYMIND_USE_SIN_33_31
+    template<>
+    struct SinTableValueSize<33, 31, true>
+    {
+        typedef SinValuesTableQ33_31 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_33_31
+
+    #if TINYMIND_USE_SIN_34_30
+    template<>
+    struct SinTableValueSize<34, 30, true>
+    {
+        typedef SinValuesTableQ34_30 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_34_30
+
+    #if TINYMIND_USE_SIN_35_29
+    template<>
+    struct SinTableValueSize<35, 29, true>
+    {
+        typedef SinValuesTableQ35_29 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_35_29
+
+    #if TINYMIND_USE_SIN_36_28
+    template<>
+    struct SinTableValueSize<36, 28, true>
+    {
+        typedef SinValuesTableQ36_28 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_36_28
+
+    #if TINYMIND_USE_SIN_37_27
+    template<>
+    struct SinTableValueSize<37, 27, true>
+    {
+        typedef SinValuesTableQ37_27 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_37_27
+
+    #if TINYMIND_USE_SIN_38_26
+    template<>
+    struct SinTableValueSize<38, 26, true>
+    {
+        typedef SinValuesTableQ38_26 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_38_26
+
+    #if TINYMIND_USE_SIN_39_25
+    template<>
+    struct SinTableValueSize<39, 25, true>
+    {
+        typedef SinValuesTableQ39_25 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_39_25
+
+    #if TINYMIND_USE_SIN_40_24
+    template<>
+    struct SinTableValueSize<40, 24, true>
+    {
+        typedef SinValuesTableQ40_24 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_40_24
+
+    #if TINYMIND_USE_SIN_41_23
+    template<>
+    struct SinTableValueSize<41, 23, true>
+    {
+        typedef SinValuesTableQ41_23 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_41_23
+
+    #if TINYMIND_USE_SIN_42_22
+    template<>
+    struct SinTableValueSize<42, 22, true>
+    {
+        typedef SinValuesTableQ42_22 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_42_22
+
+    #if TINYMIND_USE_SIN_43_21
+    template<>
+    struct SinTableValueSize<43, 21, true>
+    {
+        typedef SinValuesTableQ43_21 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_43_21
+
+    #if TINYMIND_USE_SIN_44_20
+    template<>
+    struct SinTableValueSize<44, 20, true>
+    {
+        typedef SinValuesTableQ44_20 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_44_20
+
+    #if TINYMIND_USE_SIN_45_19
+    template<>
+    struct SinTableValueSize<45, 19, true>
+    {
+        typedef SinValuesTableQ45_19 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_45_19
+
+    #if TINYMIND_USE_SIN_46_18
+    template<>
+    struct SinTableValueSize<46, 18, true>
+    {
+        typedef SinValuesTableQ46_18 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_46_18
+
+    #if TINYMIND_USE_SIN_47_17
+    template<>
+    struct SinTableValueSize<47, 17, true>
+    {
+        typedef SinValuesTableQ47_17 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_47_17
+
+    #if TINYMIND_USE_SIN_48_16
+    template<>
+    struct SinTableValueSize<48, 16, true>
+    {
+        typedef SinValuesTableQ48_16 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_48_16
+
+    #if TINYMIND_USE_SIN_49_15
+    template<>
+    struct SinTableValueSize<49, 15, true>
+    {
+        typedef SinValuesTableQ49_15 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_49_15
+
+    #if TINYMIND_USE_SIN_50_14
+    template<>
+    struct SinTableValueSize<50, 14, true>
+    {
+        typedef SinValuesTableQ50_14 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_50_14
+
+    #if TINYMIND_USE_SIN_51_13
+    template<>
+    struct SinTableValueSize<51, 13, true>
+    {
+        typedef SinValuesTableQ51_13 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_51_13
+
+    #if TINYMIND_USE_SIN_52_12
+    template<>
+    struct SinTableValueSize<52, 12, true>
+    {
+        typedef SinValuesTableQ52_12 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_52_12
+
+    #if TINYMIND_USE_SIN_53_11
+    template<>
+    struct SinTableValueSize<53, 11, true>
+    {
+        typedef SinValuesTableQ53_11 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_53_11
+
+    #if TINYMIND_USE_SIN_54_10
+    template<>
+    struct SinTableValueSize<54, 10, true>
+    {
+        typedef SinValuesTableQ54_10 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_54_10
+
+    #if TINYMIND_USE_SIN_55_9
+    template<>
+    struct SinTableValueSize<55, 9, true>
+    {
+        typedef SinValuesTableQ55_9 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_55_9
+
+    #if TINYMIND_USE_SIN_56_8
+    template<>
+    struct SinTableValueSize<56, 8, true>
+    {
+        typedef SinValuesTableQ56_8 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_56_8
+
+    #if TINYMIND_USE_SIN_57_7
+    template<>
+    struct SinTableValueSize<57, 7, true>
+    {
+        typedef SinValuesTableQ57_7 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_57_7
+
+    #if TINYMIND_USE_SIN_58_6
+    template<>
+    struct SinTableValueSize<58, 6, true>
+    {
+        typedef SinValuesTableQ58_6 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_58_6
+
+    #if TINYMIND_USE_SIN_59_5
+    template<>
+    struct SinTableValueSize<59, 5, true>
+    {
+        typedef SinValuesTableQ59_5 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_59_5
+
+    #if TINYMIND_USE_SIN_60_4
+    template<>
+    struct SinTableValueSize<60, 4, true>
+    {
+        typedef SinValuesTableQ60_4 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_60_4
+
+    #if TINYMIND_USE_SIN_61_3
+    template<>
+    struct SinTableValueSize<61, 3, true>
+    {
+        typedef SinValuesTableQ61_3 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_61_3
+
+    #if TINYMIND_USE_SIN_62_2
+    template<>
+    struct SinTableValueSize<62, 2, true>
+    {
+        typedef SinValuesTableQ62_2 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_62_2
+
+    #if TINYMIND_USE_SIN_63_1
+    template<>
+    struct SinTableValueSize<63, 1, true>
+    {
+        typedef SinValuesTableQ63_1 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_63_1
+
+    #if TINYMIND_USE_SIN_1_127
+    template<>
+    struct SinTableValueSize<1, 127, true>
+    {
+        typedef SinValuesTableQ1_127 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_1_127
+
+    #if TINYMIND_USE_SIN_2_126
+    template<>
+    struct SinTableValueSize<2, 126, true>
+    {
+        typedef SinValuesTableQ2_126 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_2_126
+
+    #if TINYMIND_USE_SIN_3_125
+    template<>
+    struct SinTableValueSize<3, 125, true>
+    {
+        typedef SinValuesTableQ3_125 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_3_125
+
+    #if TINYMIND_USE_SIN_4_124
+    template<>
+    struct SinTableValueSize<4, 124, true>
+    {
+        typedef SinValuesTableQ4_124 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_4_124
+
+    #if TINYMIND_USE_SIN_5_123
+    template<>
+    struct SinTableValueSize<5, 123, true>
+    {
+        typedef SinValuesTableQ5_123 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_5_123
+
+    #if TINYMIND_USE_SIN_6_122
+    template<>
+    struct SinTableValueSize<6, 122, true>
+    {
+        typedef SinValuesTableQ6_122 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_6_122
+
+    #if TINYMIND_USE_SIN_7_121
+    template<>
+    struct SinTableValueSize<7, 121, true>
+    {
+        typedef SinValuesTableQ7_121 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_7_121
+
+    #if TINYMIND_USE_SIN_8_120
+    template<>
+    struct SinTableValueSize<8, 120, true>
+    {
+        typedef SinValuesTableQ8_120 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_8_120
+
+    #if TINYMIND_USE_SIN_9_119
+    template<>
+    struct SinTableValueSize<9, 119, true>
+    {
+        typedef SinValuesTableQ9_119 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_9_119
+
+    #if TINYMIND_USE_SIN_10_118
+    template<>
+    struct SinTableValueSize<10, 118, true>
+    {
+        typedef SinValuesTableQ10_118 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_10_118
+
+    #if TINYMIND_USE_SIN_11_117
+    template<>
+    struct SinTableValueSize<11, 117, true>
+    {
+        typedef SinValuesTableQ11_117 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_11_117
+
+    #if TINYMIND_USE_SIN_12_116
+    template<>
+    struct SinTableValueSize<12, 116, true>
+    {
+        typedef SinValuesTableQ12_116 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_12_116
+
+    #if TINYMIND_USE_SIN_13_115
+    template<>
+    struct SinTableValueSize<13, 115, true>
+    {
+        typedef SinValuesTableQ13_115 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_13_115
+
+    #if TINYMIND_USE_SIN_14_114
+    template<>
+    struct SinTableValueSize<14, 114, true>
+    {
+        typedef SinValuesTableQ14_114 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_14_114
+
+    #if TINYMIND_USE_SIN_15_113
+    template<>
+    struct SinTableValueSize<15, 113, true>
+    {
+        typedef SinValuesTableQ15_113 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_15_113
+
+    #if TINYMIND_USE_SIN_16_112
+    template<>
+    struct SinTableValueSize<16, 112, true>
+    {
+        typedef SinValuesTableQ16_112 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_16_112
+
+    #if TINYMIND_USE_SIN_17_111
+    template<>
+    struct SinTableValueSize<17, 111, true>
+    {
+        typedef SinValuesTableQ17_111 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_17_111
+
+    #if TINYMIND_USE_SIN_18_110
+    template<>
+    struct SinTableValueSize<18, 110, true>
+    {
+        typedef SinValuesTableQ18_110 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_18_110
+
+    #if TINYMIND_USE_SIN_19_109
+    template<>
+    struct SinTableValueSize<19, 109, true>
+    {
+        typedef SinValuesTableQ19_109 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_19_109
+
+    #if TINYMIND_USE_SIN_20_108
+    template<>
+    struct SinTableValueSize<20, 108, true>
+    {
+        typedef SinValuesTableQ20_108 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_20_108
+
+    #if TINYMIND_USE_SIN_21_107
+    template<>
+    struct SinTableValueSize<21, 107, true>
+    {
+        typedef SinValuesTableQ21_107 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_21_107
+
+    #if TINYMIND_USE_SIN_22_106
+    template<>
+    struct SinTableValueSize<22, 106, true>
+    {
+        typedef SinValuesTableQ22_106 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_22_106
+
+    #if TINYMIND_USE_SIN_23_105
+    template<>
+    struct SinTableValueSize<23, 105, true>
+    {
+        typedef SinValuesTableQ23_105 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_23_105
+
+    #if TINYMIND_USE_SIN_24_104
+    template<>
+    struct SinTableValueSize<24, 104, true>
+    {
+        typedef SinValuesTableQ24_104 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_24_104
+
+    #if TINYMIND_USE_SIN_25_103
+    template<>
+    struct SinTableValueSize<25, 103, true>
+    {
+        typedef SinValuesTableQ25_103 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_25_103
+
+    #if TINYMIND_USE_SIN_26_102
+    template<>
+    struct SinTableValueSize<26, 102, true>
+    {
+        typedef SinValuesTableQ26_102 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_26_102
+
+    #if TINYMIND_USE_SIN_27_101
+    template<>
+    struct SinTableValueSize<27, 101, true>
+    {
+        typedef SinValuesTableQ27_101 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_27_101
+
+    #if TINYMIND_USE_SIN_28_100
+    template<>
+    struct SinTableValueSize<28, 100, true>
+    {
+        typedef SinValuesTableQ28_100 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_28_100
+
+    #if TINYMIND_USE_SIN_29_99
+    template<>
+    struct SinTableValueSize<29, 99, true>
+    {
+        typedef SinValuesTableQ29_99 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_29_99
+
+    #if TINYMIND_USE_SIN_30_98
+    template<>
+    struct SinTableValueSize<30, 98, true>
+    {
+        typedef SinValuesTableQ30_98 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_30_98
+
+    #if TINYMIND_USE_SIN_31_97
+    template<>
+    struct SinTableValueSize<31, 97, true>
+    {
+        typedef SinValuesTableQ31_97 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_31_97
+
+    #if TINYMIND_USE_SIN_32_96
+    template<>
+    struct SinTableValueSize<32, 96, true>
+    {
+        typedef SinValuesTableQ32_96 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_32_96
+
+    #if TINYMIND_USE_SIN_33_95
+    template<>
+    struct SinTableValueSize<33, 95, true>
+    {
+        typedef SinValuesTableQ33_95 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_33_95
+
+    #if TINYMIND_USE_SIN_34_94
+    template<>
+    struct SinTableValueSize<34, 94, true>
+    {
+        typedef SinValuesTableQ34_94 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_34_94
+
+    #if TINYMIND_USE_SIN_35_93
+    template<>
+    struct SinTableValueSize<35, 93, true>
+    {
+        typedef SinValuesTableQ35_93 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_35_93
+
+    #if TINYMIND_USE_SIN_36_92
+    template<>
+    struct SinTableValueSize<36, 92, true>
+    {
+        typedef SinValuesTableQ36_92 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_36_92
+
+    #if TINYMIND_USE_SIN_37_91
+    template<>
+    struct SinTableValueSize<37, 91, true>
+    {
+        typedef SinValuesTableQ37_91 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_37_91
+
+    #if TINYMIND_USE_SIN_38_90
+    template<>
+    struct SinTableValueSize<38, 90, true>
+    {
+        typedef SinValuesTableQ38_90 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_38_90
+
+    #if TINYMIND_USE_SIN_39_89
+    template<>
+    struct SinTableValueSize<39, 89, true>
+    {
+        typedef SinValuesTableQ39_89 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_39_89
+
+    #if TINYMIND_USE_SIN_40_88
+    template<>
+    struct SinTableValueSize<40, 88, true>
+    {
+        typedef SinValuesTableQ40_88 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_40_88
+
+    #if TINYMIND_USE_SIN_41_87
+    template<>
+    struct SinTableValueSize<41, 87, true>
+    {
+        typedef SinValuesTableQ41_87 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_41_87
+
+    #if TINYMIND_USE_SIN_42_86
+    template<>
+    struct SinTableValueSize<42, 86, true>
+    {
+        typedef SinValuesTableQ42_86 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_42_86
+
+    #if TINYMIND_USE_SIN_43_85
+    template<>
+    struct SinTableValueSize<43, 85, true>
+    {
+        typedef SinValuesTableQ43_85 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_43_85
+
+    #if TINYMIND_USE_SIN_44_84
+    template<>
+    struct SinTableValueSize<44, 84, true>
+    {
+        typedef SinValuesTableQ44_84 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_44_84
+
+    #if TINYMIND_USE_SIN_45_83
+    template<>
+    struct SinTableValueSize<45, 83, true>
+    {
+        typedef SinValuesTableQ45_83 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_45_83
+
+    #if TINYMIND_USE_SIN_46_82
+    template<>
+    struct SinTableValueSize<46, 82, true>
+    {
+        typedef SinValuesTableQ46_82 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_46_82
+
+    #if TINYMIND_USE_SIN_47_81
+    template<>
+    struct SinTableValueSize<47, 81, true>
+    {
+        typedef SinValuesTableQ47_81 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_47_81
+
+    #if TINYMIND_USE_SIN_48_80
+    template<>
+    struct SinTableValueSize<48, 80, true>
+    {
+        typedef SinValuesTableQ48_80 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_48_80
+
+    #if TINYMIND_USE_SIN_49_79
+    template<>
+    struct SinTableValueSize<49, 79, true>
+    {
+        typedef SinValuesTableQ49_79 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_49_79
+
+    #if TINYMIND_USE_SIN_50_78
+    template<>
+    struct SinTableValueSize<50, 78, true>
+    {
+        typedef SinValuesTableQ50_78 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_50_78
+
+    #if TINYMIND_USE_SIN_51_77
+    template<>
+    struct SinTableValueSize<51, 77, true>
+    {
+        typedef SinValuesTableQ51_77 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_51_77
+
+    #if TINYMIND_USE_SIN_52_76
+    template<>
+    struct SinTableValueSize<52, 76, true>
+    {
+        typedef SinValuesTableQ52_76 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_52_76
+
+    #if TINYMIND_USE_SIN_53_75
+    template<>
+    struct SinTableValueSize<53, 75, true>
+    {
+        typedef SinValuesTableQ53_75 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_53_75
+
+    #if TINYMIND_USE_SIN_54_74
+    template<>
+    struct SinTableValueSize<54, 74, true>
+    {
+        typedef SinValuesTableQ54_74 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_54_74
+
+    #if TINYMIND_USE_SIN_55_73
+    template<>
+    struct SinTableValueSize<55, 73, true>
+    {
+        typedef SinValuesTableQ55_73 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_55_73
+
+    #if TINYMIND_USE_SIN_56_72
+    template<>
+    struct SinTableValueSize<56, 72, true>
+    {
+        typedef SinValuesTableQ56_72 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_56_72
+
+    #if TINYMIND_USE_SIN_57_71
+    template<>
+    struct SinTableValueSize<57, 71, true>
+    {
+        typedef SinValuesTableQ57_71 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_57_71
+
+    #if TINYMIND_USE_SIN_58_70
+    template<>
+    struct SinTableValueSize<58, 70, true>
+    {
+        typedef SinValuesTableQ58_70 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_58_70
+
+    #if TINYMIND_USE_SIN_59_69
+    template<>
+    struct SinTableValueSize<59, 69, true>
+    {
+        typedef SinValuesTableQ59_69 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_59_69
+
+    #if TINYMIND_USE_SIN_60_68
+    template<>
+    struct SinTableValueSize<60, 68, true>
+    {
+        typedef SinValuesTableQ60_68 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_60_68
+
+    #if TINYMIND_USE_SIN_61_67
+    template<>
+    struct SinTableValueSize<61, 67, true>
+    {
+        typedef SinValuesTableQ61_67 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_61_67
+
+    #if TINYMIND_USE_SIN_62_66
+    template<>
+    struct SinTableValueSize<62, 66, true>
+    {
+        typedef SinValuesTableQ62_66 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_62_66
+
+    #if TINYMIND_USE_SIN_63_65
+    template<>
+    struct SinTableValueSize<63, 65, true>
+    {
+        typedef SinValuesTableQ63_65 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_63_65
+
+    #if TINYMIND_USE_SIN_64_64
+    template<>
+    struct SinTableValueSize<64, 64, true>
+    {
+        typedef SinValuesTableQ64_64 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_64_64
+
+    #if TINYMIND_USE_SIN_65_63
+    template<>
+    struct SinTableValueSize<65, 63, true>
+    {
+        typedef SinValuesTableQ65_63 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_65_63
+
+    #if TINYMIND_USE_SIN_66_62
+    template<>
+    struct SinTableValueSize<66, 62, true>
+    {
+        typedef SinValuesTableQ66_62 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_66_62
+
+    #if TINYMIND_USE_SIN_67_61
+    template<>
+    struct SinTableValueSize<67, 61, true>
+    {
+        typedef SinValuesTableQ67_61 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_67_61
+
+    #if TINYMIND_USE_SIN_68_60
+    template<>
+    struct SinTableValueSize<68, 60, true>
+    {
+        typedef SinValuesTableQ68_60 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_68_60
+
+    #if TINYMIND_USE_SIN_69_59
+    template<>
+    struct SinTableValueSize<69, 59, true>
+    {
+        typedef SinValuesTableQ69_59 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_69_59
+
+    #if TINYMIND_USE_SIN_70_58
+    template<>
+    struct SinTableValueSize<70, 58, true>
+    {
+        typedef SinValuesTableQ70_58 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_70_58
+
+    #if TINYMIND_USE_SIN_71_57
+    template<>
+    struct SinTableValueSize<71, 57, true>
+    {
+        typedef SinValuesTableQ71_57 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_71_57
+
+    #if TINYMIND_USE_SIN_72_56
+    template<>
+    struct SinTableValueSize<72, 56, true>
+    {
+        typedef SinValuesTableQ72_56 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_72_56
+
+    #if TINYMIND_USE_SIN_73_55
+    template<>
+    struct SinTableValueSize<73, 55, true>
+    {
+        typedef SinValuesTableQ73_55 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_73_55
+
+    #if TINYMIND_USE_SIN_74_54
+    template<>
+    struct SinTableValueSize<74, 54, true>
+    {
+        typedef SinValuesTableQ74_54 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_74_54
+
+    #if TINYMIND_USE_SIN_75_53
+    template<>
+    struct SinTableValueSize<75, 53, true>
+    {
+        typedef SinValuesTableQ75_53 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_75_53
+
+    #if TINYMIND_USE_SIN_76_52
+    template<>
+    struct SinTableValueSize<76, 52, true>
+    {
+        typedef SinValuesTableQ76_52 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_76_52
+
+    #if TINYMIND_USE_SIN_77_51
+    template<>
+    struct SinTableValueSize<77, 51, true>
+    {
+        typedef SinValuesTableQ77_51 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_77_51
+
+    #if TINYMIND_USE_SIN_78_50
+    template<>
+    struct SinTableValueSize<78, 50, true>
+    {
+        typedef SinValuesTableQ78_50 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_78_50
+
+    #if TINYMIND_USE_SIN_79_49
+    template<>
+    struct SinTableValueSize<79, 49, true>
+    {
+        typedef SinValuesTableQ79_49 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_79_49
+
+    #if TINYMIND_USE_SIN_80_48
+    template<>
+    struct SinTableValueSize<80, 48, true>
+    {
+        typedef SinValuesTableQ80_48 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_80_48
+
+    #if TINYMIND_USE_SIN_81_47
+    template<>
+    struct SinTableValueSize<81, 47, true>
+    {
+        typedef SinValuesTableQ81_47 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_81_47
+
+    #if TINYMIND_USE_SIN_82_46
+    template<>
+    struct SinTableValueSize<82, 46, true>
+    {
+        typedef SinValuesTableQ82_46 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_82_46
+
+    #if TINYMIND_USE_SIN_83_45
+    template<>
+    struct SinTableValueSize<83, 45, true>
+    {
+        typedef SinValuesTableQ83_45 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_83_45
+
+    #if TINYMIND_USE_SIN_84_44
+    template<>
+    struct SinTableValueSize<84, 44, true>
+    {
+        typedef SinValuesTableQ84_44 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_84_44
+
+    #if TINYMIND_USE_SIN_85_43
+    template<>
+    struct SinTableValueSize<85, 43, true>
+    {
+        typedef SinValuesTableQ85_43 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_85_43
+
+    #if TINYMIND_USE_SIN_86_42
+    template<>
+    struct SinTableValueSize<86, 42, true>
+    {
+        typedef SinValuesTableQ86_42 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_86_42
+
+    #if TINYMIND_USE_SIN_87_41
+    template<>
+    struct SinTableValueSize<87, 41, true>
+    {
+        typedef SinValuesTableQ87_41 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_87_41
+
+    #if TINYMIND_USE_SIN_88_40
+    template<>
+    struct SinTableValueSize<88, 40, true>
+    {
+        typedef SinValuesTableQ88_40 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_88_40
+
+    #if TINYMIND_USE_SIN_89_39
+    template<>
+    struct SinTableValueSize<89, 39, true>
+    {
+        typedef SinValuesTableQ89_39 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_89_39
+
+    #if TINYMIND_USE_SIN_90_38
+    template<>
+    struct SinTableValueSize<90, 38, true>
+    {
+        typedef SinValuesTableQ90_38 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_90_38
+
+    #if TINYMIND_USE_SIN_91_37
+    template<>
+    struct SinTableValueSize<91, 37, true>
+    {
+        typedef SinValuesTableQ91_37 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_91_37
+
+    #if TINYMIND_USE_SIN_92_36
+    template<>
+    struct SinTableValueSize<92, 36, true>
+    {
+        typedef SinValuesTableQ92_36 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_92_36
+
+    #if TINYMIND_USE_SIN_93_35
+    template<>
+    struct SinTableValueSize<93, 35, true>
+    {
+        typedef SinValuesTableQ93_35 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_93_35
+
+    #if TINYMIND_USE_SIN_94_34
+    template<>
+    struct SinTableValueSize<94, 34, true>
+    {
+        typedef SinValuesTableQ94_34 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_94_34
+
+    #if TINYMIND_USE_SIN_95_33
+    template<>
+    struct SinTableValueSize<95, 33, true>
+    {
+        typedef SinValuesTableQ95_33 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_95_33
+
+    #if TINYMIND_USE_SIN_96_32
+    template<>
+    struct SinTableValueSize<96, 32, true>
+    {
+        typedef SinValuesTableQ96_32 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_96_32
+
+    #if TINYMIND_USE_SIN_97_31
+    template<>
+    struct SinTableValueSize<97, 31, true>
+    {
+        typedef SinValuesTableQ97_31 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_97_31
+
+    #if TINYMIND_USE_SIN_98_30
+    template<>
+    struct SinTableValueSize<98, 30, true>
+    {
+        typedef SinValuesTableQ98_30 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_98_30
+
+    #if TINYMIND_USE_SIN_99_29
+    template<>
+    struct SinTableValueSize<99, 29, true>
+    {
+        typedef SinValuesTableQ99_29 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_99_29
+
+    #if TINYMIND_USE_SIN_100_28
+    template<>
+    struct SinTableValueSize<100, 28, true>
+    {
+        typedef SinValuesTableQ100_28 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_100_28
+
+    #if TINYMIND_USE_SIN_101_27
+    template<>
+    struct SinTableValueSize<101, 27, true>
+    {
+        typedef SinValuesTableQ101_27 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_101_27
+
+    #if TINYMIND_USE_SIN_102_26
+    template<>
+    struct SinTableValueSize<102, 26, true>
+    {
+        typedef SinValuesTableQ102_26 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_102_26
+
+    #if TINYMIND_USE_SIN_103_25
+    template<>
+    struct SinTableValueSize<103, 25, true>
+    {
+        typedef SinValuesTableQ103_25 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_103_25
+
+    #if TINYMIND_USE_SIN_104_24
+    template<>
+    struct SinTableValueSize<104, 24, true>
+    {
+        typedef SinValuesTableQ104_24 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_104_24
+
+    #if TINYMIND_USE_SIN_105_23
+    template<>
+    struct SinTableValueSize<105, 23, true>
+    {
+        typedef SinValuesTableQ105_23 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_105_23
+
+    #if TINYMIND_USE_SIN_106_22
+    template<>
+    struct SinTableValueSize<106, 22, true>
+    {
+        typedef SinValuesTableQ106_22 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_106_22
+
+    #if TINYMIND_USE_SIN_107_21
+    template<>
+    struct SinTableValueSize<107, 21, true>
+    {
+        typedef SinValuesTableQ107_21 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_107_21
+
+    #if TINYMIND_USE_SIN_108_20
+    template<>
+    struct SinTableValueSize<108, 20, true>
+    {
+        typedef SinValuesTableQ108_20 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_108_20
+
+    #if TINYMIND_USE_SIN_109_19
+    template<>
+    struct SinTableValueSize<109, 19, true>
+    {
+        typedef SinValuesTableQ109_19 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_109_19
+
+    #if TINYMIND_USE_SIN_110_18
+    template<>
+    struct SinTableValueSize<110, 18, true>
+    {
+        typedef SinValuesTableQ110_18 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_110_18
+
+    #if TINYMIND_USE_SIN_111_17
+    template<>
+    struct SinTableValueSize<111, 17, true>
+    {
+        typedef SinValuesTableQ111_17 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_111_17
+
+    #if TINYMIND_USE_SIN_112_16
+    template<>
+    struct SinTableValueSize<112, 16, true>
+    {
+        typedef SinValuesTableQ112_16 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_112_16
+
+    #if TINYMIND_USE_SIN_113_15
+    template<>
+    struct SinTableValueSize<113, 15, true>
+    {
+        typedef SinValuesTableQ113_15 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_113_15
+
+    #if TINYMIND_USE_SIN_114_14
+    template<>
+    struct SinTableValueSize<114, 14, true>
+    {
+        typedef SinValuesTableQ114_14 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_114_14
+
+    #if TINYMIND_USE_SIN_115_13
+    template<>
+    struct SinTableValueSize<115, 13, true>
+    {
+        typedef SinValuesTableQ115_13 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_115_13
+
+    #if TINYMIND_USE_SIN_116_12
+    template<>
+    struct SinTableValueSize<116, 12, true>
+    {
+        typedef SinValuesTableQ116_12 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_116_12
+
+    #if TINYMIND_USE_SIN_117_11
+    template<>
+    struct SinTableValueSize<117, 11, true>
+    {
+        typedef SinValuesTableQ117_11 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_117_11
+
+    #if TINYMIND_USE_SIN_118_10
+    template<>
+    struct SinTableValueSize<118, 10, true>
+    {
+        typedef SinValuesTableQ118_10 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_118_10
+
+    #if TINYMIND_USE_SIN_119_9
+    template<>
+    struct SinTableValueSize<119, 9, true>
+    {
+        typedef SinValuesTableQ119_9 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_119_9
+
+    #if TINYMIND_USE_SIN_120_8
+    template<>
+    struct SinTableValueSize<120, 8, true>
+    {
+        typedef SinValuesTableQ120_8 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_120_8
+
+    #if TINYMIND_USE_SIN_121_7
+    template<>
+    struct SinTableValueSize<121, 7, true>
+    {
+        typedef SinValuesTableQ121_7 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_121_7
+
+    #if TINYMIND_USE_SIN_122_6
+    template<>
+    struct SinTableValueSize<122, 6, true>
+    {
+        typedef SinValuesTableQ122_6 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_122_6
+
+    #if TINYMIND_USE_SIN_123_5
+    template<>
+    struct SinTableValueSize<123, 5, true>
+    {
+        typedef SinValuesTableQ123_5 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_123_5
+
+    #if TINYMIND_USE_SIN_124_4
+    template<>
+    struct SinTableValueSize<124, 4, true>
+    {
+        typedef SinValuesTableQ124_4 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_124_4
+
+    #if TINYMIND_USE_SIN_125_3
+    template<>
+    struct SinTableValueSize<125, 3, true>
+    {
+        typedef SinValuesTableQ125_3 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_125_3
+
+    #if TINYMIND_USE_SIN_126_2
+    template<>
+    struct SinTableValueSize<126, 2, true>
+    {
+        typedef SinValuesTableQ126_2 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_126_2
+
+    #if TINYMIND_USE_SIN_127_1
+    template<>
+    struct SinTableValueSize<127, 1, true>
+    {
+        typedef SinValuesTableQ127_1 SinTableType;
+    };
+    #endif // TINYMIND_USE_SIN_127_1
+
+    template<unsigned FixedBits,unsigned FracBits, bool IsSigned>
+    struct SinValuesTableSelector
+    {
+        typedef typename SinTableValueSize<FixedBits, FracBits, IsSigned>::SinTableType SinTableType;
+    };
+}

--- a/cpp/sin.hpp
+++ b/cpp/sin.hpp
@@ -19,27 +19,6 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 * SOFTWARE.
 */
-/**
-* Copyright (c) 2020 Intel Corporation
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
 
 #pragma once
 

--- a/cpp/sinValues128Bit.hpp
+++ b/cpp/sinValues128Bit.hpp
@@ -1,0 +1,811 @@
+/**
+* Copyright (c) 2026 Dan McLeran
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+/**
+* Copyright (c) 2020 Intel Corporation
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#pragma once
+
+#include "activation.hpp"
+
+namespace tinymind {
+    #if TINYMIND_USE_SIN_1_127
+    struct SinValuesTableQ1_127
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_1_127
+    #if TINYMIND_USE_SIN_2_126
+    struct SinValuesTableQ2_126
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_2_126
+    #if TINYMIND_USE_SIN_3_125
+    struct SinValuesTableQ3_125
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_3_125
+    #if TINYMIND_USE_SIN_4_124
+    struct SinValuesTableQ4_124
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_4_124
+    #if TINYMIND_USE_SIN_5_123
+    struct SinValuesTableQ5_123
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_5_123
+    #if TINYMIND_USE_SIN_6_122
+    struct SinValuesTableQ6_122
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_6_122
+    #if TINYMIND_USE_SIN_7_121
+    struct SinValuesTableQ7_121
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_7_121
+    #if TINYMIND_USE_SIN_8_120
+    struct SinValuesTableQ8_120
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_8_120
+    #if TINYMIND_USE_SIN_9_119
+    struct SinValuesTableQ9_119
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_9_119
+    #if TINYMIND_USE_SIN_10_118
+    struct SinValuesTableQ10_118
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_10_118
+    #if TINYMIND_USE_SIN_11_117
+    struct SinValuesTableQ11_117
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_11_117
+    #if TINYMIND_USE_SIN_12_116
+    struct SinValuesTableQ12_116
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_12_116
+    #if TINYMIND_USE_SIN_13_115
+    struct SinValuesTableQ13_115
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_13_115
+    #if TINYMIND_USE_SIN_14_114
+    struct SinValuesTableQ14_114
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_14_114
+    #if TINYMIND_USE_SIN_15_113
+    struct SinValuesTableQ15_113
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_15_113
+    #if TINYMIND_USE_SIN_16_112
+    struct SinValuesTableQ16_112
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_16_112
+    #if TINYMIND_USE_SIN_17_111
+    struct SinValuesTableQ17_111
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_17_111
+    #if TINYMIND_USE_SIN_18_110
+    struct SinValuesTableQ18_110
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_18_110
+    #if TINYMIND_USE_SIN_19_109
+    struct SinValuesTableQ19_109
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_19_109
+    #if TINYMIND_USE_SIN_20_108
+    struct SinValuesTableQ20_108
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_20_108
+    #if TINYMIND_USE_SIN_21_107
+    struct SinValuesTableQ21_107
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_21_107
+    #if TINYMIND_USE_SIN_22_106
+    struct SinValuesTableQ22_106
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_22_106
+    #if TINYMIND_USE_SIN_23_105
+    struct SinValuesTableQ23_105
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_23_105
+    #if TINYMIND_USE_SIN_24_104
+    struct SinValuesTableQ24_104
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_24_104
+    #if TINYMIND_USE_SIN_25_103
+    struct SinValuesTableQ25_103
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_25_103
+    #if TINYMIND_USE_SIN_26_102
+    struct SinValuesTableQ26_102
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_26_102
+    #if TINYMIND_USE_SIN_27_101
+    struct SinValuesTableQ27_101
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_27_101
+    #if TINYMIND_USE_SIN_28_100
+    struct SinValuesTableQ28_100
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_28_100
+    #if TINYMIND_USE_SIN_29_99
+    struct SinValuesTableQ29_99
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_29_99
+    #if TINYMIND_USE_SIN_30_98
+    struct SinValuesTableQ30_98
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_30_98
+    #if TINYMIND_USE_SIN_31_97
+    struct SinValuesTableQ31_97
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_31_97
+    #if TINYMIND_USE_SIN_32_96
+    struct SinValuesTableQ32_96
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_32_96
+    #if TINYMIND_USE_SIN_33_95
+    struct SinValuesTableQ33_95
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_33_95
+    #if TINYMIND_USE_SIN_34_94
+    struct SinValuesTableQ34_94
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_34_94
+    #if TINYMIND_USE_SIN_35_93
+    struct SinValuesTableQ35_93
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_35_93
+    #if TINYMIND_USE_SIN_36_92
+    struct SinValuesTableQ36_92
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_36_92
+    #if TINYMIND_USE_SIN_37_91
+    struct SinValuesTableQ37_91
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_37_91
+    #if TINYMIND_USE_SIN_38_90
+    struct SinValuesTableQ38_90
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_38_90
+    #if TINYMIND_USE_SIN_39_89
+    struct SinValuesTableQ39_89
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_39_89
+    #if TINYMIND_USE_SIN_40_88
+    struct SinValuesTableQ40_88
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_40_88
+    #if TINYMIND_USE_SIN_41_87
+    struct SinValuesTableQ41_87
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_41_87
+    #if TINYMIND_USE_SIN_42_86
+    struct SinValuesTableQ42_86
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_42_86
+    #if TINYMIND_USE_SIN_43_85
+    struct SinValuesTableQ43_85
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_43_85
+    #if TINYMIND_USE_SIN_44_84
+    struct SinValuesTableQ44_84
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_44_84
+    #if TINYMIND_USE_SIN_45_83
+    struct SinValuesTableQ45_83
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_45_83
+    #if TINYMIND_USE_SIN_46_82
+    struct SinValuesTableQ46_82
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_46_82
+    #if TINYMIND_USE_SIN_47_81
+    struct SinValuesTableQ47_81
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_47_81
+    #if TINYMIND_USE_SIN_48_80
+    struct SinValuesTableQ48_80
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_48_80
+    #if TINYMIND_USE_SIN_49_79
+    struct SinValuesTableQ49_79
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_49_79
+    #if TINYMIND_USE_SIN_50_78
+    struct SinValuesTableQ50_78
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_50_78
+    #if TINYMIND_USE_SIN_51_77
+    struct SinValuesTableQ51_77
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_51_77
+    #if TINYMIND_USE_SIN_52_76
+    struct SinValuesTableQ52_76
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_52_76
+    #if TINYMIND_USE_SIN_53_75
+    struct SinValuesTableQ53_75
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_53_75
+    #if TINYMIND_USE_SIN_54_74
+    struct SinValuesTableQ54_74
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_54_74
+    #if TINYMIND_USE_SIN_55_73
+    struct SinValuesTableQ55_73
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_55_73
+    #if TINYMIND_USE_SIN_56_72
+    struct SinValuesTableQ56_72
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_56_72
+    #if TINYMIND_USE_SIN_57_71
+    struct SinValuesTableQ57_71
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_57_71
+    #if TINYMIND_USE_SIN_58_70
+    struct SinValuesTableQ58_70
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_58_70
+    #if TINYMIND_USE_SIN_59_69
+    struct SinValuesTableQ59_69
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_59_69
+    #if TINYMIND_USE_SIN_60_68
+    struct SinValuesTableQ60_68
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_60_68
+    #if TINYMIND_USE_SIN_61_67
+    struct SinValuesTableQ61_67
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_61_67
+    #if TINYMIND_USE_SIN_62_66
+    struct SinValuesTableQ62_66
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_62_66
+    #if TINYMIND_USE_SIN_63_65
+    struct SinValuesTableQ63_65
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_63_65
+    #if TINYMIND_USE_SIN_64_64
+    struct SinValuesTableQ64_64
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_64_64
+    #if TINYMIND_USE_SIN_65_63
+    struct SinValuesTableQ65_63
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_65_63
+    #if TINYMIND_USE_SIN_66_62
+    struct SinValuesTableQ66_62
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_66_62
+    #if TINYMIND_USE_SIN_67_61
+    struct SinValuesTableQ67_61
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_67_61
+    #if TINYMIND_USE_SIN_68_60
+    struct SinValuesTableQ68_60
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_68_60
+    #if TINYMIND_USE_SIN_69_59
+    struct SinValuesTableQ69_59
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_69_59
+    #if TINYMIND_USE_SIN_70_58
+    struct SinValuesTableQ70_58
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_70_58
+    #if TINYMIND_USE_SIN_71_57
+    struct SinValuesTableQ71_57
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_71_57
+    #if TINYMIND_USE_SIN_72_56
+    struct SinValuesTableQ72_56
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_72_56
+    #if TINYMIND_USE_SIN_73_55
+    struct SinValuesTableQ73_55
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_73_55
+    #if TINYMIND_USE_SIN_74_54
+    struct SinValuesTableQ74_54
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_74_54
+    #if TINYMIND_USE_SIN_75_53
+    struct SinValuesTableQ75_53
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_75_53
+    #if TINYMIND_USE_SIN_76_52
+    struct SinValuesTableQ76_52
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_76_52
+    #if TINYMIND_USE_SIN_77_51
+    struct SinValuesTableQ77_51
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_77_51
+    #if TINYMIND_USE_SIN_78_50
+    struct SinValuesTableQ78_50
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_78_50
+    #if TINYMIND_USE_SIN_79_49
+    struct SinValuesTableQ79_49
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_79_49
+    #if TINYMIND_USE_SIN_80_48
+    struct SinValuesTableQ80_48
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_80_48
+    #if TINYMIND_USE_SIN_81_47
+    struct SinValuesTableQ81_47
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_81_47
+    #if TINYMIND_USE_SIN_82_46
+    struct SinValuesTableQ82_46
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_82_46
+    #if TINYMIND_USE_SIN_83_45
+    struct SinValuesTableQ83_45
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_83_45
+    #if TINYMIND_USE_SIN_84_44
+    struct SinValuesTableQ84_44
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_84_44
+    #if TINYMIND_USE_SIN_85_43
+    struct SinValuesTableQ85_43
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_85_43
+    #if TINYMIND_USE_SIN_86_42
+    struct SinValuesTableQ86_42
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_86_42
+    #if TINYMIND_USE_SIN_87_41
+    struct SinValuesTableQ87_41
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_87_41
+    #if TINYMIND_USE_SIN_88_40
+    struct SinValuesTableQ88_40
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_88_40
+    #if TINYMIND_USE_SIN_89_39
+    struct SinValuesTableQ89_39
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_89_39
+    #if TINYMIND_USE_SIN_90_38
+    struct SinValuesTableQ90_38
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_90_38
+    #if TINYMIND_USE_SIN_91_37
+    struct SinValuesTableQ91_37
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_91_37
+    #if TINYMIND_USE_SIN_92_36
+    struct SinValuesTableQ92_36
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_92_36
+    #if TINYMIND_USE_SIN_93_35
+    struct SinValuesTableQ93_35
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_93_35
+    #if TINYMIND_USE_SIN_94_34
+    struct SinValuesTableQ94_34
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_94_34
+    #if TINYMIND_USE_SIN_95_33
+    struct SinValuesTableQ95_33
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_95_33
+    #if TINYMIND_USE_SIN_96_32
+    struct SinValuesTableQ96_32
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_96_32
+    #if TINYMIND_USE_SIN_97_31
+    struct SinValuesTableQ97_31
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_97_31
+    #if TINYMIND_USE_SIN_98_30
+    struct SinValuesTableQ98_30
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_98_30
+    #if TINYMIND_USE_SIN_99_29
+    struct SinValuesTableQ99_29
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_99_29
+    #if TINYMIND_USE_SIN_100_28
+    struct SinValuesTableQ100_28
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_100_28
+    #if TINYMIND_USE_SIN_101_27
+    struct SinValuesTableQ101_27
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_101_27
+    #if TINYMIND_USE_SIN_102_26
+    struct SinValuesTableQ102_26
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_102_26
+    #if TINYMIND_USE_SIN_103_25
+    struct SinValuesTableQ103_25
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_103_25
+    #if TINYMIND_USE_SIN_104_24
+    struct SinValuesTableQ104_24
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_104_24
+    #if TINYMIND_USE_SIN_105_23
+    struct SinValuesTableQ105_23
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_105_23
+    #if TINYMIND_USE_SIN_106_22
+    struct SinValuesTableQ106_22
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_106_22
+    #if TINYMIND_USE_SIN_107_21
+    struct SinValuesTableQ107_21
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_107_21
+    #if TINYMIND_USE_SIN_108_20
+    struct SinValuesTableQ108_20
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_108_20
+    #if TINYMIND_USE_SIN_109_19
+    struct SinValuesTableQ109_19
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_109_19
+    #if TINYMIND_USE_SIN_110_18
+    struct SinValuesTableQ110_18
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_110_18
+    #if TINYMIND_USE_SIN_111_17
+    struct SinValuesTableQ111_17
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_111_17
+    #if TINYMIND_USE_SIN_112_16
+    struct SinValuesTableQ112_16
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_112_16
+    #if TINYMIND_USE_SIN_113_15
+    struct SinValuesTableQ113_15
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_113_15
+    #if TINYMIND_USE_SIN_114_14
+    struct SinValuesTableQ114_14
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_114_14
+    #if TINYMIND_USE_SIN_115_13
+    struct SinValuesTableQ115_13
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_115_13
+    #if TINYMIND_USE_SIN_116_12
+    struct SinValuesTableQ116_12
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_116_12
+    #if TINYMIND_USE_SIN_117_11
+    struct SinValuesTableQ117_11
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_117_11
+    #if TINYMIND_USE_SIN_118_10
+    struct SinValuesTableQ118_10
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_118_10
+    #if TINYMIND_USE_SIN_119_9
+    struct SinValuesTableQ119_9
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_119_9
+    #if TINYMIND_USE_SIN_120_8
+    struct SinValuesTableQ120_8
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_120_8
+    #if TINYMIND_USE_SIN_121_7
+    struct SinValuesTableQ121_7
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_121_7
+    #if TINYMIND_USE_SIN_122_6
+    struct SinValuesTableQ122_6
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_122_6
+    #if TINYMIND_USE_SIN_123_5
+    struct SinValuesTableQ123_5
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_123_5
+    #if TINYMIND_USE_SIN_124_4
+    struct SinValuesTableQ124_4
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_124_4
+    #if TINYMIND_USE_SIN_125_3
+    struct SinValuesTableQ125_3
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_125_3
+    #if TINYMIND_USE_SIN_126_2
+    struct SinValuesTableQ126_2
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_126_2
+    #if TINYMIND_USE_SIN_127_1
+    struct SinValuesTableQ127_1
+    {
+        static const uint128_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_127_1
+}

--- a/cpp/sinValues128Bit.hpp
+++ b/cpp/sinValues128Bit.hpp
@@ -19,27 +19,6 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 * SOFTWARE.
 */
-/**
-* Copyright (c) 2020 Intel Corporation
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
 
 #pragma once
 

--- a/cpp/sinValues16Bit.hpp
+++ b/cpp/sinValues16Bit.hpp
@@ -19,27 +19,6 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 * SOFTWARE.
 */
-/**
-* Copyright (c) 2020 Intel Corporation
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
 
 #pragma once
 

--- a/cpp/sinValues16Bit.hpp
+++ b/cpp/sinValues16Bit.hpp
@@ -1,0 +1,139 @@
+/**
+* Copyright (c) 2026 Dan McLeran
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+/**
+* Copyright (c) 2020 Intel Corporation
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#pragma once
+
+#include "activation.hpp"
+
+namespace tinymind {
+    #if TINYMIND_USE_SIN_1_15
+    struct SinValuesTableQ1_15
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_1_15
+    #if TINYMIND_USE_SIN_2_14
+    struct SinValuesTableQ2_14
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_2_14
+    #if TINYMIND_USE_SIN_3_13
+    struct SinValuesTableQ3_13
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_3_13
+    #if TINYMIND_USE_SIN_4_12
+    struct SinValuesTableQ4_12
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_4_12
+    #if TINYMIND_USE_SIN_5_11
+    struct SinValuesTableQ5_11
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_5_11
+    #if TINYMIND_USE_SIN_6_10
+    struct SinValuesTableQ6_10
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_6_10
+    #if TINYMIND_USE_SIN_7_9
+    struct SinValuesTableQ7_9
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_7_9
+    #if TINYMIND_USE_SIN_8_8
+    struct SinValuesTableQ8_8
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_8_8
+    #if TINYMIND_USE_SIN_9_7
+    struct SinValuesTableQ9_7
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_9_7
+    #if TINYMIND_USE_SIN_10_6
+    struct SinValuesTableQ10_6
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_10_6
+    #if TINYMIND_USE_SIN_11_5
+    struct SinValuesTableQ11_5
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_11_5
+    #if TINYMIND_USE_SIN_12_4
+    struct SinValuesTableQ12_4
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_12_4
+    #if TINYMIND_USE_SIN_13_3
+    struct SinValuesTableQ13_3
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_13_3
+    #if TINYMIND_USE_SIN_14_2
+    struct SinValuesTableQ14_2
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_14_2
+    #if TINYMIND_USE_SIN_15_1
+    struct SinValuesTableQ15_1
+    {
+        static const uint16_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_15_1
+}

--- a/cpp/sinValues32Bit.hpp
+++ b/cpp/sinValues32Bit.hpp
@@ -19,27 +19,6 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 * SOFTWARE.
 */
-/**
-* Copyright (c) 2020 Intel Corporation
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
 
 #pragma once
 

--- a/cpp/sinValues32Bit.hpp
+++ b/cpp/sinValues32Bit.hpp
@@ -1,0 +1,235 @@
+/**
+* Copyright (c) 2026 Dan McLeran
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+/**
+* Copyright (c) 2020 Intel Corporation
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#pragma once
+
+#include "activation.hpp"
+
+namespace tinymind {
+    #if TINYMIND_USE_SIN_1_31
+    struct SinValuesTableQ1_31
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_1_31
+    #if TINYMIND_USE_SIN_2_30
+    struct SinValuesTableQ2_30
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_2_30
+    #if TINYMIND_USE_SIN_3_29
+    struct SinValuesTableQ3_29
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_3_29
+    #if TINYMIND_USE_SIN_4_28
+    struct SinValuesTableQ4_28
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_4_28
+    #if TINYMIND_USE_SIN_5_27
+    struct SinValuesTableQ5_27
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_5_27
+    #if TINYMIND_USE_SIN_6_26
+    struct SinValuesTableQ6_26
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_6_26
+    #if TINYMIND_USE_SIN_7_25
+    struct SinValuesTableQ7_25
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_7_25
+    #if TINYMIND_USE_SIN_8_24
+    struct SinValuesTableQ8_24
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_8_24
+    #if TINYMIND_USE_SIN_9_23
+    struct SinValuesTableQ9_23
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_9_23
+    #if TINYMIND_USE_SIN_10_22
+    struct SinValuesTableQ10_22
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_10_22
+    #if TINYMIND_USE_SIN_11_21
+    struct SinValuesTableQ11_21
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_11_21
+    #if TINYMIND_USE_SIN_12_20
+    struct SinValuesTableQ12_20
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_12_20
+    #if TINYMIND_USE_SIN_13_19
+    struct SinValuesTableQ13_19
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_13_19
+    #if TINYMIND_USE_SIN_14_18
+    struct SinValuesTableQ14_18
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_14_18
+    #if TINYMIND_USE_SIN_15_17
+    struct SinValuesTableQ15_17
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_15_17
+    #if TINYMIND_USE_SIN_16_16
+    struct SinValuesTableQ16_16
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_16_16
+    #if TINYMIND_USE_SIN_17_15
+    struct SinValuesTableQ17_15
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_17_15
+    #if TINYMIND_USE_SIN_18_14
+    struct SinValuesTableQ18_14
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_18_14
+    #if TINYMIND_USE_SIN_19_13
+    struct SinValuesTableQ19_13
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_19_13
+    #if TINYMIND_USE_SIN_20_12
+    struct SinValuesTableQ20_12
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_20_12
+    #if TINYMIND_USE_SIN_21_11
+    struct SinValuesTableQ21_11
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_21_11
+    #if TINYMIND_USE_SIN_22_10
+    struct SinValuesTableQ22_10
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_22_10
+    #if TINYMIND_USE_SIN_23_9
+    struct SinValuesTableQ23_9
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_23_9
+    #if TINYMIND_USE_SIN_24_8
+    struct SinValuesTableQ24_8
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_24_8
+    #if TINYMIND_USE_SIN_25_7
+    struct SinValuesTableQ25_7
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_25_7
+    #if TINYMIND_USE_SIN_26_6
+    struct SinValuesTableQ26_6
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_26_6
+    #if TINYMIND_USE_SIN_27_5
+    struct SinValuesTableQ27_5
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_27_5
+    #if TINYMIND_USE_SIN_28_4
+    struct SinValuesTableQ28_4
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_28_4
+    #if TINYMIND_USE_SIN_29_3
+    struct SinValuesTableQ29_3
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_29_3
+    #if TINYMIND_USE_SIN_30_2
+    struct SinValuesTableQ30_2
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_30_2
+    #if TINYMIND_USE_SIN_31_1
+    struct SinValuesTableQ31_1
+    {
+        static const uint32_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_31_1
+}

--- a/cpp/sinValues64Bit.hpp
+++ b/cpp/sinValues64Bit.hpp
@@ -1,0 +1,427 @@
+/**
+* Copyright (c) 2026 Dan McLeran
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+/**
+* Copyright (c) 2020 Intel Corporation
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#pragma once
+
+#include "activation.hpp"
+
+namespace tinymind {
+    #if TINYMIND_USE_SIN_1_63
+    struct SinValuesTableQ1_63
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_1_63
+    #if TINYMIND_USE_SIN_2_62
+    struct SinValuesTableQ2_62
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_2_62
+    #if TINYMIND_USE_SIN_3_61
+    struct SinValuesTableQ3_61
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_3_61
+    #if TINYMIND_USE_SIN_4_60
+    struct SinValuesTableQ4_60
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_4_60
+    #if TINYMIND_USE_SIN_5_59
+    struct SinValuesTableQ5_59
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_5_59
+    #if TINYMIND_USE_SIN_6_58
+    struct SinValuesTableQ6_58
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_6_58
+    #if TINYMIND_USE_SIN_7_57
+    struct SinValuesTableQ7_57
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_7_57
+    #if TINYMIND_USE_SIN_8_56
+    struct SinValuesTableQ8_56
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_8_56
+    #if TINYMIND_USE_SIN_9_55
+    struct SinValuesTableQ9_55
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_9_55
+    #if TINYMIND_USE_SIN_10_54
+    struct SinValuesTableQ10_54
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_10_54
+    #if TINYMIND_USE_SIN_11_53
+    struct SinValuesTableQ11_53
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_11_53
+    #if TINYMIND_USE_SIN_12_52
+    struct SinValuesTableQ12_52
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_12_52
+    #if TINYMIND_USE_SIN_13_51
+    struct SinValuesTableQ13_51
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_13_51
+    #if TINYMIND_USE_SIN_14_50
+    struct SinValuesTableQ14_50
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_14_50
+    #if TINYMIND_USE_SIN_15_49
+    struct SinValuesTableQ15_49
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_15_49
+    #if TINYMIND_USE_SIN_16_48
+    struct SinValuesTableQ16_48
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_16_48
+    #if TINYMIND_USE_SIN_17_47
+    struct SinValuesTableQ17_47
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_17_47
+    #if TINYMIND_USE_SIN_18_46
+    struct SinValuesTableQ18_46
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_18_46
+    #if TINYMIND_USE_SIN_19_45
+    struct SinValuesTableQ19_45
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_19_45
+    #if TINYMIND_USE_SIN_20_44
+    struct SinValuesTableQ20_44
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_20_44
+    #if TINYMIND_USE_SIN_21_43
+    struct SinValuesTableQ21_43
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_21_43
+    #if TINYMIND_USE_SIN_22_42
+    struct SinValuesTableQ22_42
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_22_42
+    #if TINYMIND_USE_SIN_23_41
+    struct SinValuesTableQ23_41
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_23_41
+    #if TINYMIND_USE_SIN_24_40
+    struct SinValuesTableQ24_40
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_24_40
+    #if TINYMIND_USE_SIN_25_39
+    struct SinValuesTableQ25_39
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_25_39
+    #if TINYMIND_USE_SIN_26_38
+    struct SinValuesTableQ26_38
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_26_38
+    #if TINYMIND_USE_SIN_27_37
+    struct SinValuesTableQ27_37
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_27_37
+    #if TINYMIND_USE_SIN_28_36
+    struct SinValuesTableQ28_36
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_28_36
+    #if TINYMIND_USE_SIN_29_35
+    struct SinValuesTableQ29_35
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_29_35
+    #if TINYMIND_USE_SIN_30_34
+    struct SinValuesTableQ30_34
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_30_34
+    #if TINYMIND_USE_SIN_31_33
+    struct SinValuesTableQ31_33
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_31_33
+    #if TINYMIND_USE_SIN_32_32
+    struct SinValuesTableQ32_32
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_32_32
+    #if TINYMIND_USE_SIN_33_31
+    struct SinValuesTableQ33_31
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_33_31
+    #if TINYMIND_USE_SIN_34_30
+    struct SinValuesTableQ34_30
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_34_30
+    #if TINYMIND_USE_SIN_35_29
+    struct SinValuesTableQ35_29
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_35_29
+    #if TINYMIND_USE_SIN_36_28
+    struct SinValuesTableQ36_28
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_36_28
+    #if TINYMIND_USE_SIN_37_27
+    struct SinValuesTableQ37_27
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_37_27
+    #if TINYMIND_USE_SIN_38_26
+    struct SinValuesTableQ38_26
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_38_26
+    #if TINYMIND_USE_SIN_39_25
+    struct SinValuesTableQ39_25
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_39_25
+    #if TINYMIND_USE_SIN_40_24
+    struct SinValuesTableQ40_24
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_40_24
+    #if TINYMIND_USE_SIN_41_23
+    struct SinValuesTableQ41_23
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_41_23
+    #if TINYMIND_USE_SIN_42_22
+    struct SinValuesTableQ42_22
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_42_22
+    #if TINYMIND_USE_SIN_43_21
+    struct SinValuesTableQ43_21
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_43_21
+    #if TINYMIND_USE_SIN_44_20
+    struct SinValuesTableQ44_20
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_44_20
+    #if TINYMIND_USE_SIN_45_19
+    struct SinValuesTableQ45_19
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_45_19
+    #if TINYMIND_USE_SIN_46_18
+    struct SinValuesTableQ46_18
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_46_18
+    #if TINYMIND_USE_SIN_47_17
+    struct SinValuesTableQ47_17
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_47_17
+    #if TINYMIND_USE_SIN_48_16
+    struct SinValuesTableQ48_16
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_48_16
+    #if TINYMIND_USE_SIN_49_15
+    struct SinValuesTableQ49_15
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_49_15
+    #if TINYMIND_USE_SIN_50_14
+    struct SinValuesTableQ50_14
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_50_14
+    #if TINYMIND_USE_SIN_51_13
+    struct SinValuesTableQ51_13
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_51_13
+    #if TINYMIND_USE_SIN_52_12
+    struct SinValuesTableQ52_12
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_52_12
+    #if TINYMIND_USE_SIN_53_11
+    struct SinValuesTableQ53_11
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_53_11
+    #if TINYMIND_USE_SIN_54_10
+    struct SinValuesTableQ54_10
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_54_10
+    #if TINYMIND_USE_SIN_55_9
+    struct SinValuesTableQ55_9
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_55_9
+    #if TINYMIND_USE_SIN_56_8
+    struct SinValuesTableQ56_8
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_56_8
+    #if TINYMIND_USE_SIN_57_7
+    struct SinValuesTableQ57_7
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_57_7
+    #if TINYMIND_USE_SIN_58_6
+    struct SinValuesTableQ58_6
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_58_6
+    #if TINYMIND_USE_SIN_59_5
+    struct SinValuesTableQ59_5
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_59_5
+    #if TINYMIND_USE_SIN_60_4
+    struct SinValuesTableQ60_4
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_60_4
+    #if TINYMIND_USE_SIN_61_3
+    struct SinValuesTableQ61_3
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_61_3
+    #if TINYMIND_USE_SIN_62_2
+    struct SinValuesTableQ62_2
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_62_2
+    #if TINYMIND_USE_SIN_63_1
+    struct SinValuesTableQ63_1
+    {
+        static const uint64_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_63_1
+}

--- a/cpp/sinValues64Bit.hpp
+++ b/cpp/sinValues64Bit.hpp
@@ -19,27 +19,6 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 * SOFTWARE.
 */
-/**
-* Copyright (c) 2020 Intel Corporation
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
 
 #pragma once
 

--- a/cpp/sinValues8Bit.hpp
+++ b/cpp/sinValues8Bit.hpp
@@ -1,0 +1,91 @@
+/**
+* Copyright (c) 2026 Dan McLeran
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+/**
+* Copyright (c) 2020 Intel Corporation
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#pragma once
+
+#include "activation.hpp"
+
+namespace tinymind {
+    #if TINYMIND_USE_SIN_1_7
+    struct SinValuesTableQ1_7
+    {
+        static const uint8_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_1_7
+    #if TINYMIND_USE_SIN_2_6
+    struct SinValuesTableQ2_6
+    {
+        static const uint8_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_2_6
+    #if TINYMIND_USE_SIN_3_5
+    struct SinValuesTableQ3_5
+    {
+        static const uint8_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_3_5
+    #if TINYMIND_USE_SIN_4_4
+    struct SinValuesTableQ4_4
+    {
+        static const uint8_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_4_4
+    #if TINYMIND_USE_SIN_5_3
+    struct SinValuesTableQ5_3
+    {
+        static const uint8_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_5_3
+    #if TINYMIND_USE_SIN_6_2
+    struct SinValuesTableQ6_2
+    {
+        static const uint8_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_6_2
+    #if TINYMIND_USE_SIN_7_1
+    struct SinValuesTableQ7_1
+    {
+        static const uint8_t values[NUMBER_OF_ACTIVATION_TABLE_VALUES];
+    };
+    #endif // TINYMIND_USE_SIN_7_1
+}

--- a/cpp/sinValues8Bit.hpp
+++ b/cpp/sinValues8Bit.hpp
@@ -19,27 +19,6 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 * SOFTWARE.
 */
-/**
-* Copyright (c) 2020 Intel Corporation
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
 
 #pragma once
 

--- a/cpp/tanh.hpp
+++ b/cpp/tanh.hpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023 Dan McLeran
+* Copyright (c) 2026 Dan McLeran
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/cpp/tanhValues128Bit.hpp
+++ b/cpp/tanhValues128Bit.hpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023 Dan McLeran
+* Copyright (c) 2026 Dan McLeran
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/cpp/tanhValues16Bit.hpp
+++ b/cpp/tanhValues16Bit.hpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023 Dan McLeran
+* Copyright (c) 2026 Dan McLeran
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/cpp/tanhValues32Bit.hpp
+++ b/cpp/tanhValues32Bit.hpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023 Dan McLeran
+* Copyright (c) 2026 Dan McLeran
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/cpp/tanhValues64Bit.hpp
+++ b/cpp/tanhValues64Bit.hpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023 Dan McLeran
+* Copyright (c) 2026 Dan McLeran
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/cpp/tanhValues8Bit.hpp
+++ b/cpp/tanhValues8Bit.hpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023 Dan McLeran
+* Copyright (c) 2026 Dan McLeran
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/unit_test/nn/nn_unit_test.cpp
+++ b/unit_test/nn/nn_unit_test.cpp
@@ -52,6 +52,7 @@ TINYMIND_DISABLE_WARNING_POP
 #include "binarylayer.hpp"
 #include "ternarylayer.hpp"
 #include "selfattention1d.hpp"
+#include "fft1d.hpp"
 #include "networkStats.hpp"
 #include "random.hpp"
 #include "nnproperties.hpp"
@@ -5859,6 +5860,316 @@ BOOST_AUTO_TEST_CASE(test_case_selfattention1d_fixed_point_bias)
     BOOST_TEST(std::abs(output[1].getValue() - expected12.getValue()) <= tolerance);
     BOOST_TEST(std::abs(output[2].getValue() - expected8.getValue()) <= tolerance);
     BOOST_TEST(std::abs(output[3].getValue() - expected12.getValue()) <= tolerance);
+}
+
+// ============================================================================
+// FFT1D tests
+// ============================================================================
+
+BOOST_AUTO_TEST_CASE(test_case_fft1d_static_sizes)
+{
+    typedef tinymind::FFT1D<double, 8> FFTType;
+
+    static_assert(FFTType::Length == 8, "Wrong FFT length");
+    static_assert(FFTType::HalfLength == 4, "Wrong half length");
+    static_assert(FFTType::NumStages == 3, "Wrong number of stages");
+    BOOST_TEST(true);
+}
+
+BOOST_AUTO_TEST_CASE(test_case_fft1d_float_dc_signal)
+{
+    // A constant (DC) signal should produce energy only in bin 0
+    const size_t N = 8;
+    tinymind::FFT1D<double, N> fft;
+
+    // Compute twiddle factors
+    double cosTable[N / 2];
+    double sinTable[N / 2];
+    for (size_t k = 0; k < N / 2; ++k)
+    {
+        cosTable[k] = std::cos(-2.0 * M_PI * k / N);
+        sinTable[k] = std::sin(-2.0 * M_PI * k / N);
+    }
+    fft.setTwiddleFactors(cosTable, sinTable);
+
+    double real[N] = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+    double imag[N] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+
+    fft.forward(real, imag);
+
+    // Scaled FFT divides by N, so DC bin = sum/N = 8/8 = 1.0
+    BOOST_TEST(fabs(real[0] - 1.0) < 0.001);
+    BOOST_TEST(fabs(imag[0]) < 0.001);
+
+    // All other bins should be zero
+    for (size_t i = 1; i < N; ++i)
+    {
+        BOOST_TEST(fabs(real[i]) < 0.001);
+        BOOST_TEST(fabs(imag[i]) < 0.001);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_case_fft1d_float_impulse)
+{
+    // Impulse at index 0: FFT should produce constant magnitude across all bins
+    const size_t N = 8;
+    tinymind::FFT1D<double, N> fft;
+
+    double cosTable[N / 2];
+    double sinTable[N / 2];
+    for (size_t k = 0; k < N / 2; ++k)
+    {
+        cosTable[k] = std::cos(-2.0 * M_PI * k / N);
+        sinTable[k] = std::sin(-2.0 * M_PI * k / N);
+    }
+    fft.setTwiddleFactors(cosTable, sinTable);
+
+    double real[N] = {1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+    double imag[N] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+
+    fft.forward(real, imag);
+
+    // Scaled by 1/N, so each bin should have magnitude 1/N = 0.125
+    double magSq[N];
+    tinymind::FFT1D<double, N>::magnitudeSquared(real, imag, magSq);
+
+    const double expectedMagSq = (1.0 / N) * (1.0 / N); // 0.015625
+    for (size_t i = 0; i < N; ++i)
+    {
+        BOOST_TEST(fabs(magSq[i] - expectedMagSq) < 0.001);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_case_fft1d_float_nyquist)
+{
+    // Alternating +1/-1 signal: energy at Nyquist frequency (bin N/2)
+    const size_t N = 8;
+    tinymind::FFT1D<double, N> fft;
+
+    double cosTable[N / 2];
+    double sinTable[N / 2];
+    for (size_t k = 0; k < N / 2; ++k)
+    {
+        cosTable[k] = std::cos(-2.0 * M_PI * k / N);
+        sinTable[k] = std::sin(-2.0 * M_PI * k / N);
+    }
+    fft.setTwiddleFactors(cosTable, sinTable);
+
+    double real[N] = {1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0};
+    double imag[N] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+
+    fft.forward(real, imag);
+
+    // Scaled FFT: Nyquist bin (N/2=4) should have magnitude 1.0
+    BOOST_TEST(fabs(real[N / 2] - 1.0) < 0.001);
+    BOOST_TEST(fabs(imag[N / 2]) < 0.001);
+
+    // All other bins should be zero
+    for (size_t i = 0; i < N; ++i)
+    {
+        if (i != N / 2)
+        {
+            BOOST_TEST(fabs(real[i]) < 0.001);
+            BOOST_TEST(fabs(imag[i]) < 0.001);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_case_fft1d_float_roundtrip)
+{
+    // Forward then inverse should recover the original signal
+    const size_t N = 8;
+    tinymind::FFT1D<double, N> fft;
+
+    double cosTable[N / 2];
+    double sinTable[N / 2];
+    for (size_t k = 0; k < N / 2; ++k)
+    {
+        cosTable[k] = std::cos(-2.0 * M_PI * k / N);
+        sinTable[k] = std::sin(-2.0 * M_PI * k / N);
+    }
+    fft.setTwiddleFactors(cosTable, sinTable);
+
+    double original[N] = {0.1, 0.5, -0.3, 0.8, -0.2, 0.6, 0.0, -0.4};
+    double real[N];
+    double imag[N];
+    for (size_t i = 0; i < N; ++i)
+    {
+        real[i] = original[i];
+        imag[i] = 0.0;
+    }
+
+    fft.forward(real, imag);
+    fft.inverse(real, imag);
+
+    // Should recover original (within floating-point tolerance)
+    for (size_t i = 0; i < N; ++i)
+    {
+        BOOST_TEST(fabs(real[i] - original[i]) < 0.001);
+        BOOST_TEST(fabs(imag[i]) < 0.001);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_case_fft1d_float_single_frequency)
+{
+    // Pure cosine at bin 1 frequency
+    const size_t N = 16;
+    tinymind::FFT1D<double, N> fft;
+
+    double cosTable[N / 2];
+    double sinTable[N / 2];
+    for (size_t k = 0; k < N / 2; ++k)
+    {
+        cosTable[k] = std::cos(-2.0 * M_PI * k / N);
+        sinTable[k] = std::sin(-2.0 * M_PI * k / N);
+    }
+    fft.setTwiddleFactors(cosTable, sinTable);
+
+    double real[N];
+    double imag[N];
+    for (size_t i = 0; i < N; ++i)
+    {
+        real[i] = std::cos(2.0 * M_PI * i / N); // frequency bin 1
+        imag[i] = 0.0;
+    }
+
+    fft.forward(real, imag);
+
+    // Scaled FFT: bins 1 and N-1 should have magnitude 0.5
+    // (cosine splits into positive and negative frequency)
+    BOOST_TEST(fabs(real[1] - 0.5) < 0.001);
+    BOOST_TEST(fabs(imag[1]) < 0.001);
+    BOOST_TEST(fabs(real[N - 1] - 0.5) < 0.001);
+    BOOST_TEST(fabs(imag[N - 1]) < 0.001);
+
+    // All other bins should be near zero
+    for (size_t i = 0; i < N; ++i)
+    {
+        if (i != 1 && i != N - 1)
+        {
+            BOOST_TEST(fabs(real[i]) < 0.001);
+            BOOST_TEST(fabs(imag[i]) < 0.001);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_case_fft1d_float_magnitude_squared)
+{
+    // Verify magnitudeSquared computes real^2 + imag^2
+    const size_t N = 4;
+    double real[N] = {3.0, 0.0, -1.0, 0.0};
+    double imag[N] = {4.0, 0.0, 2.0, 0.0};
+    double magSq[N];
+
+    tinymind::FFT1D<double, N>::magnitudeSquared(real, imag, magSq);
+
+    BOOST_TEST(fabs(magSq[0] - 25.0) < 0.001); // 9 + 16
+    BOOST_TEST(fabs(magSq[1] - 0.0) < 0.001);
+    BOOST_TEST(fabs(magSq[2] - 5.0) < 0.001);  // 1 + 4
+    BOOST_TEST(fabs(magSq[3] - 0.0) < 0.001);
+}
+
+BOOST_AUTO_TEST_CASE(test_case_fft1d_fixed_point_dc_signal)
+{
+    // DC signal test with Q8.8 fixed-point
+    typedef tinymind::QValue<8, 8, true, tinymind::RoundUpPolicy> ValueType;
+    const size_t N = 8;
+    tinymind::FFT1D<ValueType, N> fft;
+
+    // Pre-computed twiddle factors for N=8: cos(-2*pi*k/8) and sin(-2*pi*k/8)
+    // k=0: cos(0)=1, sin(0)=0
+    // k=1: cos(-pi/4)=0.707, sin(-pi/4)=-0.707
+    // k=2: cos(-pi/2)=0, sin(-pi/2)=-1
+    // k=3: cos(-3pi/4)=-0.707, sin(-3pi/4)=-0.707
+    ValueType cosTable[N / 2];
+    ValueType sinTable[N / 2];
+    cosTable[0] = ValueType(1, 0);
+    cosTable[1] = ValueType(0, 181);  // ~0.707
+    cosTable[2] = ValueType(0, 0);
+    cosTable[3] = ValueType(-1, 75);  // ~-0.707
+
+    sinTable[0] = ValueType(0, 0);
+    sinTable[1] = ValueType(-1, 75);  // ~-0.707
+    sinTable[2] = ValueType(-1, 0);
+    sinTable[3] = ValueType(-1, 75);  // ~-0.707
+
+    fft.setTwiddleFactors(cosTable, sinTable);
+
+    ValueType real[N];
+    ValueType imag[N];
+    for (size_t i = 0; i < N; ++i)
+    {
+        real[i] = ValueType(1, 0);
+        imag[i] = ValueType(0);
+    }
+
+    fft.forward(real, imag);
+
+    // DC bin should have the dominant energy
+    // With scaled FFT, DC = 1.0 (sum/N = 8/8)
+    ValueType expected(1, 0);
+    const typename ValueType::FullWidthValueType tolerance = 3 << (ValueType::NumberOfFractionalBits - 3);
+
+    BOOST_TEST(std::abs(real[0].getValue() - expected.getValue()) <= tolerance);
+    BOOST_TEST(std::abs(imag[0].getValue()) <= tolerance);
+
+    // Other bins should be near zero
+    for (size_t i = 1; i < N; ++i)
+    {
+        BOOST_TEST(std::abs(real[i].getValue()) <= tolerance);
+        BOOST_TEST(std::abs(imag[i].getValue()) <= tolerance);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_case_fft1d_fixed_point_roundtrip)
+{
+    // Forward then inverse should approximately recover the signal
+    typedef tinymind::QValue<8, 8, true, tinymind::RoundUpPolicy> ValueType;
+    const size_t N = 8;
+    tinymind::FFT1D<ValueType, N> fft;
+
+    ValueType cosTable[N / 2];
+    ValueType sinTable[N / 2];
+    cosTable[0] = ValueType(1, 0);
+    cosTable[1] = ValueType(0, 181);
+    cosTable[2] = ValueType(0, 0);
+    cosTable[3] = ValueType(-1, 75);
+
+    sinTable[0] = ValueType(0, 0);
+    sinTable[1] = ValueType(-1, 75);
+    sinTable[2] = ValueType(-1, 0);
+    sinTable[3] = ValueType(-1, 75);
+
+    fft.setTwiddleFactors(cosTable, sinTable);
+
+    ValueType original[N];
+    original[0] = ValueType(0, 128); // 0.5
+    original[1] = ValueType(1, 0);
+    original[2] = ValueType(-1, 0);
+    original[3] = ValueType(0, 64);  // 0.25
+    original[4] = ValueType(0, 0);
+    original[5] = ValueType(0, 192); // 0.75
+    original[6] = ValueType(-1, 128); // -0.5
+    original[7] = ValueType(0, 32);  // 0.125
+
+    ValueType real[N];
+    ValueType imag[N];
+    for (size_t i = 0; i < N; ++i)
+    {
+        real[i] = original[i];
+        imag[i] = ValueType(0);
+    }
+
+    fft.forward(real, imag);
+    fft.inverse(real, imag);
+
+    // With Q8.8 and 3 stages, expect some rounding error
+    // Tolerance: ~4 LSBs of the fractional part
+    const typename ValueType::FullWidthValueType tolerance = 4;
+    for (size_t i = 0; i < N; ++i)
+    {
+        BOOST_TEST(std::abs(real[i].getValue() - original[i].getValue()) <= tolerance);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- Add radix-2 decimation-in-time FFT layer (`fft1d.hpp`) with compile-time bit-reversal tables, scaled butterfly stages to prevent fixed-point overflow, and support for both Q-format and float/double types
- Add sin/cos activation functions to the LUT generator and regenerate all lookup tables
- New generated headers: `sin.hpp`, `cos.hpp`, `sinValues*.hpp`, `cosValues*.hpp`

## Test plan
- [x] All existing tests pass (`make check` — 190 tests across nn, qformat, qlearn, kan)
- [x] All examples build cleanly (xor, maze, dqn_maze, kan_xor)
- [x] LUT generator builds and runs successfully with sin/cos additions
- [x] Add FFT unit tests for float and Q-format types

🤖 Generated with [Claude Code](https://claude.com/claude-code)