### PR TITLE
ci: add TSan gate over the OpenMP conv path

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -22,6 +22,23 @@ jobs:
           BOOST_HOME: /usr
         run: make sanitize
 
+  tsan:
+    # Data races in the TINYMIND_ENABLE_OPENMP=1 conv output-filter loop --
+    # the library's only concurrent code. No other gate covers this class:
+    # ASan/UBSan don't detect races and the OPENMP=1 corner otherwise never
+    # executes in CI. Clang + libomp (TSan-annotated); GCC's libgomp would
+    # report false races on its own barriers.
+    name: TSan (OpenMP conv path)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install toolchain
+        run: sudo apt-get update && sudo apt-get install -y clang libomp-dev libboost-dev libboost-test-dev
+      - name: Build and run OpenMP-enabled suites under TSan
+        env:
+          BOOST_HOME: /usr
+        run: make tsan
+
   cppcheck:
     name: cppcheck
     runs-on: ubuntu-latest

--- a/.tsan-suppressions
+++ b/.tsan-suppressions
@@ -1,0 +1,10 @@
+# ThreadSanitizer suppressions for `make tsan`.
+#
+# Ubuntu's packaged libomp.so is not built with TSan instrumentation, so TSan
+# cannot see the runtime's internal synchronization and reports false races on
+# libomp's own mutex/alloc/thread bookkeeping (every frame inside libomp.so,
+# with the user frame being merely the parallel-region entry). Suppress the
+# interceptors called from inside the runtime; races between TinyMind's own
+# instrumented loop iterations still report with TinyMind frames at the
+# racing accesses and are NOT suppressed by this rule.
+called_from_lib:libomp

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,16 @@ TSAN_WARN   ?= -Wall -Wextra -Wpedantic -g
 # ignore_noninstrumented_modules + the called_from_lib suppression silence the
 # false races TSan reports inside the (uninstrumented) packaged libomp runtime;
 # races between TinyMind's own instrumented loop iterations still report.
-TSAN_ENV    ?= TSAN_OPTIONS="halt_on_error=1 ignore_noninstrumented_modules=1 suppressions=$(CURDIR)/.tsan-suppressions" OMP_NUM_THREADS=4
+#
+# Archer (libarcher.so, ships with libomp-dev) must be loaded via
+# OMP_TOOL_LIBRARIES: the packaged libomp's internal synchronization is
+# invisible to TSan, so without Archer the implicit barrier at the end of a
+# parallel-for carries no happens-before edge and every post-loop read of the
+# output buffer reports as a false race against the loop's writes. Archer
+# restores those edges through OMPT callbacks.
+TSAN_ARCHER ?= $(firstword $(wildcard /usr/lib/llvm-*/lib/libarcher.so))
+TSAN_ENV    ?= TSAN_OPTIONS="halt_on_error=1 ignore_noninstrumented_modules=1 suppressions=$(CURDIR)/.tsan-suppressions" \
+               OMP_TOOL_LIBRARIES=$(TSAN_ARCHER) OMP_NUM_THREADS=4
 TSAN_SUITES = unit_test/quantization examples/resnet_block_int8 \
               examples/resnet18_block_int8 examples/mobilenetv2_int8 \
               examples/kws_cortex_m_int8

--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,33 @@ sanitize :
 	done
 	@echo "sanitize: ASan+UBSan clean across all runtime suites and int8 examples"
 
+# TSan over the OpenMP conv path. TINYMIND_ENABLE_OPENMP=1 parallelizes the
+# QConv2D / QConv2DPerChannel output-filter loop -- the only concurrent code in
+# the library -- and no other gate can see a data race there: ASan/UBSan don't
+# detect races, the static analyzers can't prove thread-safety of the
+# parallel-for, and a racy test can pass 999 runs out of 1000. The suite list
+# is the quantization tests plus the conv-heavy int8 examples, i.e. everything
+# that instantiates the parallelized loop. Clang + libomp is required: GCC's
+# libgomp is not TSan-annotated and reports false races on its own barriers
+# (sudo apt install clang libomp-dev). OMP_NUM_THREADS is pinned > 1 so the
+# loop actually runs concurrently on small CI runners.
+TSAN_CC     ?= clang++ -fsanitize=thread -fopenmp -DTINYMIND_ENABLE_OPENMP=1 -O1
+TSAN_WARN   ?= -Wall -Wextra -Wpedantic -g
+TSAN_ENV    ?= TSAN_OPTIONS=halt_on_error=1 OMP_NUM_THREADS=4
+TSAN_SUITES = unit_test/quantization examples/resnet_block_int8 \
+              examples/resnet18_block_int8 examples/mobilenetv2_int8 \
+              examples/kws_cortex_m_int8
+
+tsan :
+	@for d in $(TSAN_SUITES); do \
+		echo "=== tsan: $$d ==="; \
+		( cd $$d && $(MAKE) clean >/dev/null 2>&1 && \
+		  $(MAKE) CC="$(TSAN_CC)" WARN="$(TSAN_WARN)" >/dev/null && \
+		  $(TSAN_ENV) $(MAKE) CC="$(TSAN_CC)" WARN="$(TSAN_WARN)" run ) \
+		  || { echo "TSAN FAIL: $$d"; exit 1; }; \
+	done
+	@echo "tsan: no data races in the OpenMP conv path"
+
 cppcheck :
 	@command -v cppcheck >/dev/null 2>&1 || { echo "ERROR: cppcheck not found. sudo apt install cppcheck"; exit 1; }
 	cppcheck --enable=warning,portability --std=c++17 --language=c++ \

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,10 @@ sanitize :
 # loop actually runs concurrently on small CI runners.
 TSAN_CC     ?= clang++ -fsanitize=thread -fopenmp -DTINYMIND_ENABLE_OPENMP=1 -O1
 TSAN_WARN   ?= -Wall -Wextra -Wpedantic -g
-TSAN_ENV    ?= TSAN_OPTIONS=halt_on_error=1 OMP_NUM_THREADS=4
+# ignore_noninstrumented_modules + the called_from_lib suppression silence the
+# false races TSan reports inside the (uninstrumented) packaged libomp runtime;
+# races between TinyMind's own instrumented loop iterations still report.
+TSAN_ENV    ?= TSAN_OPTIONS="halt_on_error=1 ignore_noninstrumented_modules=1 suppressions=$(CURDIR)/.tsan-suppressions" OMP_NUM_THREADS=4
 TSAN_SUITES = unit_test/quantization examples/resnet_block_int8 \
               examples/resnet18_block_int8 examples/mobilenetv2_int8 \
               examples/kws_cortex_m_int8

--- a/README.md
+++ b/README.md
@@ -890,6 +890,7 @@ Every push and pull request runs the [Static & Dynamic Analysis](.github/workflo
 | Gate | Tool | Status | Reproduce locally |
 |---|---|---|---|
 | Memory / UB sanitizers | Clang ASan + UBSan over all runtime suites + int8 examples | **Blocking** | `make sanitize` |
+| Data races | Clang TSan over the OpenMP-parallelized conv path | **Blocking** | `make tsan` |
 | Static analysis | cppcheck (warning + portability), all headers | **Blocking** | `make cppcheck` |
 | Coverage floor | gcov + lcov, `cpp/` line/function floors | **Blocking** | `make coverage && make coverage-check` |
 | Formal proofs | CBMC over the fixed-point `qformat` kernels | **Blocking** | `make -C formal prove` |

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,7 @@ TinyMind networks are small enough to deploy on the most constrained microcontro
 [![Static & Dynamic Analysis](https://github.com/danmcleran/tinymind/actions/workflows/analysis.yml/badge.svg)](https://github.com/danmcleran/tinymind/actions/workflows/analysis.yml)
 [![CodeQL](https://github.com/danmcleran/tinymind/actions/workflows/codeql.yml/badge.svg)](https://github.com/danmcleran/tinymind/actions/workflows/codeql.yml)
 
-Every push and pull request is gated. **Blocking** gates (must pass to merge): Clang ASan + UBSan sanitizers, cppcheck static analysis, an lcov coverage floor, CBMC formal proofs of the fixed-point kernels, time-boxed libFuzzer fuzzing of the int8 kernels, and a CodeQL semantic scan. **Advisory** gates (surfaced as report artifacts, never blocking): MISRA C:2012 and clang-tidy (which also runs the Clang Static Analyzer via its `clang-analyzer-*` checks). See the [README's Quality Gates](https://github.com/danmcleran/tinymind#quality-gates) section for the full matrix and the `make` target that reproduces each one locally.
+Every push and pull request is gated. **Blocking** gates (must pass to merge): Clang ASan + UBSan sanitizers, Clang TSan over the OpenMP conv path, cppcheck static analysis, an lcov coverage floor, CBMC formal proofs of the fixed-point kernels, time-boxed libFuzzer fuzzing of the int8 kernels, and a CodeQL semantic scan. **Advisory** gates (surfaced as report artifacts, never blocking): MISRA C:2012 and clang-tidy (which also runs the Clang Static Analyzer via its `clang-analyzer-*` checks). See the [README's Quality Gates](https://github.com/danmcleran/tinymind#quality-gates) section for the full matrix and the `make` target that reproduces each one locally.
 
 ## Network Architectures
 


### PR DESCRIPTION
## Summary
- New `make tsan` target: builds and runs the quantization suite + conv-heavy int8 examples (`resnet_block_int8`, `resnet18_block_int8`, `mobilenetv2_int8`, `kws_cortex_m_int8`) with `clang++ -fsanitize=thread -fopenmp -DTINYMIND_ENABLE_OPENMP=1`, `OMP_NUM_THREADS=4`.
- New `TSan (OpenMP conv path)` job in `analysis.yml` (no `continue-on-error` — blocking intent).
- README gate table + Pages doc updated.

## Why
The `TINYMIND_ENABLE_OPENMP=1` parallel output-filter loop in `QConv2D`/`QConv2DPerChannel` is the only concurrent code in the library and previously never executed in CI. Data races are invisible to every existing gate: ASan/UBSan don't detect them, static analysis can't prove thread-safety of the parallel-for, and racy code can pass deterministic tests indefinitely. TSan is the one tool that catches this class.

Clang + libomp specifically (`libomp-dev` installed in the job): GCC's libgomp is not TSan-annotated and reports false races on its own barriers.

## Note on branch protection
Required checks are pinned by literal job name. To make this gate actually merge-blocking, add **`TSan (OpenMP conv path)`** to the required checks in branch protection settings (admin action).

## Test plan
- [x] `OPENMP=1` corner builds and passes quantization suite + mobilenetv2 golden check multithreaded locally (g++ -fopenmp)
- [x] `analysis.yml` YAML parses clean
- [ ] TSan job green on this PR's own CI run (local TSan runtime unavailable: kernel ASLR entropy issue + libomp not installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)