### PR TITLE
docs: add nightly-fuzz status badge to README + Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Static & Dynamic Analysis](https://github.com/danmcleran/tinymind/actions/workflows/analysis.yml/badge.svg)](https://github.com/danmcleran/tinymind/actions/workflows/analysis.yml)
 [![CodeQL](https://github.com/danmcleran/tinymind/actions/workflows/codeql.yml/badge.svg)](https://github.com/danmcleran/tinymind/actions/workflows/codeql.yml)
+[![Fuzz (nightly exploratory)](https://github.com/danmcleran/tinymind/actions/workflows/fuzz-nightly.yml/badge.svg)](https://github.com/danmcleran/tinymind/actions/workflows/fuzz-nightly.yml)
 
 A header-only C++ template library for neural networks, Kolmogorov-Arnold Networks (KAN), LSTM and GRU recurrent networks, liquid neural networks (LTC and CfC continuous-time cells), linear self-attention, FFT-based signal processing, 1D and 2D convolutions (including MobileNet-style depthwise-separable blocks), binary and ternary neural networks, and Q-learning, designed for embedded systems with no FPU, GPU, or vectorized instruction requirements.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,7 @@ TinyMind networks are small enough to deploy on the most constrained microcontro
 
 [![Static & Dynamic Analysis](https://github.com/danmcleran/tinymind/actions/workflows/analysis.yml/badge.svg)](https://github.com/danmcleran/tinymind/actions/workflows/analysis.yml)
 [![CodeQL](https://github.com/danmcleran/tinymind/actions/workflows/codeql.yml/badge.svg)](https://github.com/danmcleran/tinymind/actions/workflows/codeql.yml)
+[![Fuzz (nightly exploratory)](https://github.com/danmcleran/tinymind/actions/workflows/fuzz-nightly.yml/badge.svg)](https://github.com/danmcleran/tinymind/actions/workflows/fuzz-nightly.yml)
 
 Every push and pull request is gated. **Blocking** gates (must pass to merge): Clang ASan + UBSan sanitizers, Clang TSan over the OpenMP conv path, ASan+UBSan with the AVX2 SIMD backend active plus a scalar-vs-AVX2 differential fuzz harness, cppcheck static analysis, an lcov coverage floor, CBMC formal proofs of the fixed-point kernels, time-boxed libFuzzer fuzzing of the int8 kernels, and a CodeQL semantic scan. **Advisory** gates (surfaced as report artifacts, never blocking): MISRA C:2012 and clang-tidy (which also runs the Clang Static Analyzer via its `clang-analyzer-*` checks). See the [README's Quality Gates](https://github.com/danmcleran/tinymind#quality-gates) section for the full matrix and the `make` target that reproduces each one locally.
 


### PR DESCRIPTION
## Summary
- Adds the `fuzz-nightly.yml` workflow badge alongside the existing Static & Dynamic Analysis and CodeQL badges in `README.md` and `docs/index.md`.
- The nightly exploratory fuzz status (corpus-accumulating libFuzzer runs — the workflow that caught the qfft1d overflow) was previously invisible to a casual observer; the two existing badges only cover the PR-gate workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)