### PR TITLE
style: convert remaining K&R braces to Allman

### DIFF
--- a/apps/activation/activationTableGenerator.cpp
+++ b/apps/activation/activationTableGenerator.cpp
@@ -310,7 +310,8 @@ static void writeLutValues(string path, const size_t totalBits, uint64_t fixedBi
 
         // Handle the bit shift calculation carefully for large fracBits
         double leftShift;
-        if (fracBits <= 63) {
+        if (fracBits <= 63)
+        {
             leftShift = static_cast<double>(1ULL << fracBits);
         } else {
             // For fracBits > 63, calculate 2^fracBits using pow
@@ -346,14 +347,16 @@ static void writeLutValues(string path, const size_t totalBits, uint64_t fixedBi
                     uint64_t high = static_cast<uint64_t>(val128 >> 64);
                     uint64_t low = static_cast<uint64_t>(val128);
                     
-                    if (high != 0) {
+                    if (high != 0)
+                    {
                         outFile << spaces << "            0x" << std::hex << std::uppercase << high << std::setfill('0') << std::setw(16) << low << "," << endl;
                     } else {
                         outFile << spaces << "            0x" << std::hex << std::uppercase << low << "," << endl;
                     }
 #else
                     // Fallback: split the double into high and low parts
-                    if (num >= pow(2.0, 64.0)) {
+                    if (num >= pow(2.0, 64.0))
+                    {
                         uint64_t high = static_cast<uint64_t>(num / pow(2.0, 64.0));
                         uint64_t low = static_cast<uint64_t>(fmod(num, pow(2.0, 64.0)));
                         outFile << spaces << "            0x" << std::hex << std::uppercase << high << std::setfill('0') << std::setw(16) << low << "," << endl;

--- a/cpp/qformat.hpp
+++ b/cpp/qformat.hpp
@@ -92,7 +92,8 @@ namespace tinymind {
 
             T result{};
 
-            switch (opType) {
+            switch (opType)
+            {
                 case AdditionOp:
                     result = origValue + target;
                     break;
@@ -118,60 +119,94 @@ namespace tinymind {
         static T saturate(const T& origValue, const T& target, const T& minValue, const T& maxValue, const OperatorType_e opType)
         {
             T result{};
-            switch (opType) {
+            switch (opType)
+            {
                 case AdditionOp:
-                    if (target > 0) {
-                        if (origValue > (maxValue - target)) {
+                    if (target > 0)
+                    {
+                        if (origValue > (maxValue - target))
+                        {
                             result = maxValue; // Saturate to maximum
-                        } else {
+                        }
+                        else
+                        {
                             result = origValue + target;  // Safe addition
                         }
-                    } else if (target < 0) {
-                        if (origValue < (minValue - target)) {
+                    }
+                    else if (target < 0)
+                    {
+                        if (origValue < (minValue - target))
+                        {
                             result = minValue; // Saturate to minimum
-                        } else {
+                        }
+                        else
+                        {
                             result = origValue + target;  // Safe addition
                         }
-                    } else {
+                    }
+                    else
+                    {
                         result = origValue; // Adding zero: no overflow possible
                     }
                     break;
                 case SubtractionOp:
-                    if (target > 0) {
-                        if (origValue < (minValue + target)) {
+                    if (target > 0)
+                    {
+                        if (origValue < (minValue + target))
+                        {
                             result = minValue;  // Saturate to minimum
-                        } else {
+                        }
+                        else
+                        {
                             result = origValue - target; // Safe subtraction
                         }
-                    } else if (target < 0) {
-                        if (origValue > (maxValue + target)) {
+                    }
+                    else if (target < 0)
+                    {
+                        if (origValue > (maxValue + target))
+                        {
                             result = maxValue; // Saturate to maximum
-                        } else {
+                        }
+                        else
+                        {
                             result = origValue - target; // Safe subtraction
                         }
-                    } else {
+                    }
+                    else
+                    {
                         result = origValue; // Subtracting zero: no overflow possible
                     }
                     break;
                 case MultiplicationOp:
                     // Check for multiplication overflow
-                    if ((origValue * target) > maxValue) {
+                    if ((origValue * target) > maxValue)
+                    {
                         result = maxValue;
                     // Check for multiplication underflow as well    
-                    } else if ((origValue * target) < minValue) {
+                    }
+                    else if ((origValue * target) < minValue)
+                    {
                         result = minValue;
-                    } else {
+                    }
+                    else
+                    {
                         result = origValue * target; // Safe multiplication
                     }
                     break;
                 case DivisionOp:
                     if (target == 0) { // Handle division by zero first
                         result = (origValue > 0) ? maxValue : minValue;
-                    } else if ((origValue / target) > maxValue) {
+                    }
+                    else if ((origValue / target) > maxValue)
+                    {
                         result = maxValue;
-                    } else if ((origValue / target) < minValue) {
+                    }
+                    else if ((origValue / target) < minValue)
+                    {
                         result = minValue;
-                    } else {
+                    }
+                    else
+                    {
                         result = origValue / target; // Safe division
                     }
                     break;

--- a/examples/perf_matrix/perf_matrix.cpp
+++ b/examples/perf_matrix/perf_matrix.cpp
@@ -156,7 +156,8 @@ void initialize()
 
     fillSawtooth(dw_w, DwType::TotalWeights, 31);
     fillI32     (dw_b, DwType::Channels,      7);
-    for (std::size_t c = 0; c < DwType::Channels; ++c) {
+    for (std::size_t c = 0; c < DwType::Channels; ++c)
+    {
         dw_req[c] = defaultRequantizer();
     }
 
@@ -172,7 +173,8 @@ template<typename Layer>
 double benchPwOrConv(Layer& layer, const int8_t* in, int8_t* out, int iters)
 {
     auto t0 = std::chrono::steady_clock::now();
-    for (int i = 0; i < iters; ++i) {
+    for (int i = 0; i < iters; ++i)
+    {
         layer.forward(in, out);
     }
     auto t1 = std::chrono::steady_clock::now();
@@ -187,7 +189,8 @@ int64_t outputChecksum(const int8_t* p, std::size_t n)
     // value is unchanged.
     uint64_t sum = 0;
     uint64_t mix = 1469598103934665603ULL;
-    for (std::size_t i = 0; i < n; ++i) {
+    for (std::size_t i = 0; i < n; ++i)
+    {
         const uint64_t v = static_cast<uint64_t>(static_cast<int64_t>(p[i]));
         sum += v;
         mix ^= v + (mix << 5) + (mix >> 2);

--- a/unit_test/nn/nn_unit_test.cpp
+++ b/unit_test/nn/nn_unit_test.cpp
@@ -2312,9 +2312,11 @@ BOOST_AUTO_TEST_CASE(test_softmax_2x2_image_2_classes)
     
     // Linear transformation: logits = weights * input + bias
     SignedQ8_8SatPolicyType logits[numClasses];
-    for (size_t c = 0; c < numClasses; ++c) {
+    for (size_t c = 0; c < numClasses; ++c)
+    {
         logits[c] = bias[c];
-        for (size_t i = 0; i < inputSize; ++i) {
+        for (size_t i = 0; i < inputSize; ++i)
+        {
             logits[c] += weights[c][i] * inputImage[i];
         }
     }
@@ -2329,7 +2331,8 @@ BOOST_AUTO_TEST_CASE(test_softmax_2x2_image_2_classes)
     
     // Verify: Sum of probabilities should be close to 1.0
     SignedQ8_8SatPolicyType sum(0, 0);
-    for (size_t c = 0; c < numClasses; ++c) {
+    for (size_t c = 0; c < numClasses; ++c)
+    {
         sum += probabilities[c];
     }
     
@@ -2347,7 +2350,8 @@ BOOST_AUTO_TEST_CASE(test_softmax_2x2_image_2_classes)
     BOOST_TEST(sumValue <= (expectedValue + tolerance));
     
     // Verify each probability is in [0, 1] range
-    for (size_t c = 0; c < numClasses; ++c) {
+    for (size_t c = 0; c < numClasses; ++c)
+    {
         BOOST_TEST(probabilities[c].getValue() >= 0);
         BOOST_TEST(probabilities[c].getValue() <= SignedQ8_8SatPolicyType(1, 0).getValue());
     }


### PR DESCRIPTION
## What

The codebase is Allman by convention (~7300 opening braces on their own line). An audit found 33 statement-trailing `){` braces; of those, ~7 are idiomatic (lambda bodies + one brace inside a doc comment). This converts the 24 genuine K&R/OTBS control blocks to Allman and tidies the cuddled-else chains.

## Changes

- `cpp/qformat.hpp` — saturation `switch` + nested `if/else if` cluster: opening braces moved to their own line; cuddled `} else` / `} else if` split into true Allman (own-line `}`, `else`, `{`).
- `apps/activation/activationTableGenerator.cpp` — 3 `if` blocks.
- `examples/perf_matrix/perf_matrix.cpp` — 3 `for` loops.
- `unit_test/nn/nn_unit_test.cpp` — 4 `for` loops.

Lambdas (trailing brace is idiomatic) and the brace inside `cpp/earlyStopping.hpp`'s doc comment were intentionally left unchanged.

## Verification

No behavior change (whitespace only). Built and ran locally: qformat unit test (No errors), nn unit test (No errors), perf_matrix and the activation generator both compile clean. Line endings preserved per file (qformat/nn/activation are CRLF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)