### PR TITLE
docs(readme): drop stale Dyna-Q bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,6 @@ Fixed-point activations use pre-computed lookup tables for speed. Floating-point
 - Tabular Q-learning with configurable reward and learning policies
 - Deep Q-Network (DQN) with neural network function approximation
 - Experience replay buffer for DQN training
-- Dyna-Q hybrid model-free/model-based learning
 
 ### Benchmark Harness (`cpp/include/bench/`)
 


### PR DESCRIPTION
Removes the "Dyna-Q hybrid model-free/model-based learning" bullet from the README Q-Learning section. It referenced `cpp/dynaq.hpp` — a non-functional stub (constructor only, no users) deleted in #137. No working Dyna-Q implementation remains, so the claim was stale.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)