### PR TITLE
docs(architectures): add real-world use-case callouts

### DIFF
--- a/docs/architectures/conv-pooling.md
+++ b/docs/architectures/conv-pooling.md
@@ -7,6 +7,8 @@ nav_order: 3
 
 # Convolutional and Pooling Layers
 
+> **Real-world use:** a wrist-worn fall detector turns a raw 50 Hz accelerometer stream into discriminative features before a tiny classifier ever sees it. A `Conv1D -> MaxPool1D -> Dropout` pipeline in 1,825 bytes of Q8.8 runs on a coin-cell wearable, catching the impact signature without a learned Fourier or feature stage burning model capacity.
+
 Tinymind provides standalone composable signal processing layers for both 1D time-series and 2D spatial feature extraction:
 
 - **1D:** `Conv1D`, `MaxPool1D`, `AvgPool1D`, `BatchNorm1D`, `Dropout`

--- a/docs/architectures/decision-trees.md
+++ b/docs/architectures/decision-trees.md
@@ -7,6 +7,8 @@ nav_order: 12
 
 # Decision Trees & GBDT
 
+> **Real-world use:** a pump controller decides on/off from a handful of temperature, pressure, and flow readings. A gradient-boosted tree ensemble walks root-to-leaf with nothing but integer compares and branches — no matmul, no activation tables — making it the cheapest model the microcontroller can run, and a better fit for tabular sensor data than a dense net.
+
 TinyMind provides an int8 **decision-tree** family — single trees and
 gradient-boosted ensembles — as a non-neural model family. Tree inference is
 the cheapest model a microcontroller can run: a walk from root to leaf is a

--- a/docs/architectures/fft.md
+++ b/docs/architectures/fft.md
@@ -7,6 +7,8 @@ nav_order: 6
 
 # FFT1D -- Fixed-Point Fast Fourier Transform
 
+> **Real-world use:** an industrial bearing monitor watches for a specific fault frequency. A 64-point fixed-point FFT turns the raw vibration stream into spectral bins, so a tiny classifier reads the energy at the fault harmonic directly instead of spending model capacity learning the Fourier basis from raw samples.
+
 Tinymind provides `FFT1D`, a standalone radix-2 decimation-in-time FFT for power-of-two lengths. It is designed for embedded signal processing where frequency-domain features feed into a neural network classifier. All dimensions are compile-time template parameters with zero dynamic allocation.
 
 ## Why FFT for Embedded ML?

--- a/docs/architectures/int8-quantization.md
+++ b/docs/architectures/int8-quantization.md
@@ -7,6 +7,8 @@ nav_order: 5
 
 # Int8 Affine Quantization
 
+> **Real-world use:** a MobileNet-style image classifier trained in PyTorch ships to a Cortex-M with no FPU. Post-training int8 calibration maps the trained float weights onto an int8 grid, so the deployed model keeps its accuracy while every inference op stays pure integer — the same TFLite-shape path the rest of the embedded ecosystem expects.
+
 TinyMind ships a TFLite / CMSIS-NN style **post-training int8** layer family that lives alongside the existing `QValue` Q-format pipeline and the float pipeline. Weights and activations are int8, accumulators are int32, and a per-layer integer **Requantizer** (Q0.31 multiplier + shift) rescales between layers without any floating-point math on the inference path.
 
 This is a different kind of "quantization" than [BinaryDense / TernaryDense]({{ site.baseurl }}/architectures/quantized-networks). Those layers binarize / ternarize the weights themselves (1- or 2-bit storage, multiply-free MACs). The int8 path keeps a full integer multiply-accumulate but maps the float distribution onto an int8 grid via a calibrated `(scale, zero_point)` per tensor.

--- a/docs/architectures/kan.md
+++ b/docs/architectures/kan.md
@@ -7,6 +7,8 @@ nav_order: 2
 
 # Kolmogorov-Arnold Networks (KAN)
 
+> **Real-world use:** an on-device soft sensor replaces a hand-tuned calibration lookup table. A small KAN learns the smooth, nonlinear response curve that maps a raw gas or temperature reading to a corrected value, fitting the curve in its B-spline edges in ~1.2 KB — adapting to the part instead of shipping a fixed table.
+
 Tinymind implements [Kolmogorov-Arnold Networks](https://en.wikipedia.org/wiki/Kolmogorov%E2%80%93Arnold_representation_theorem) (KAN), a neural network architecture where learnable activation functions are placed on the edges (connections) rather than at the nodes. In a KAN, each edge has its own B-spline activation function, and nodes simply sum their inputs. This is in contrast to standard MLPs where edges carry scalar weights and nodes apply a shared activation function.
 
 KAN can be more parameter-efficient than MLP for certain smooth, low-dimensional functions, learning the activation shape rather than relying on fixed activations with learned weights.

--- a/docs/architectures/lstm-gru.md
+++ b/docs/architectures/lstm-gru.md
@@ -7,6 +7,8 @@ nav_order: 1
 
 # LSTM and GRU Recurrent Networks
 
+> **Real-world use:** a battery-powered sleep tracker classifies sleep stages on the wrist from a continuous PPG and accelerometer stream. An 808-byte GRU carries the temporal context across the night, so the device decides locally — no radio, no cloud round-trip — and the battery lasts because nothing leaves the chip.
+
 Tinymind provides three recurrent neural network architectures for learning from sequential data: Elman (simple recurrent), LSTM (Long Short-Term Memory), and GRU (Gated Recurrent Unit). All are implemented as C++ templates and support both fixed-point and floating-point value types.
 
 Recurrent networks maintain internal state across time steps, making them suitable for tasks like sequence prediction, time-series forecasting, and temporal pattern recognition. The key architectural difference from feed-forward networks is that hidden neurons receive feedback connections from the previous time step.

--- a/docs/architectures/mixed-precision.md
+++ b/docs/architectures/mixed-precision.md
@@ -7,6 +7,8 @@ nav_order: 8
 
 # Mixed Precision
 
+> **Real-world use:** a smart-doorbell camera runs an int8 CNN frontend to extract cheap features, hands off to an fp16 attention head for the part that needs the extra range, then projects back to int8 for the final classifier. Each block runs at the precision it actually needs, and the `qbridge` converters only fire once per tensor crossing — not on every MAC.
+
 TinyMind composes its three numeric pipelines through a small set of **pointwise converters** that live at layer boundaries, plus a software half-precision storage tier. A single network can run an int8 affine CNN frontend, hand off to a Q-format LSTM head, hand off again to an fp16 attention block, and project back to int8 for the classifier — every layer keeps the runtime cost of its own grid, the bridges only run once per tensor crossing.
 
 ## Three pipelines, one model

--- a/docs/architectures/mixture-of-experts.md
+++ b/docs/architectures/mixture-of-experts.md
@@ -7,6 +7,8 @@ nav_order: 9
 
 # Mixture of Experts
 
+> **Real-world use:** a gesture-control hub must recognize many different gesture vocabularies but only ever uses one at a time. N specialist experts hold the combined capacity in flash, a top-1 router picks the one that fits the current context, and only that expert runs — so per-inference compute stays flat even as the bank of supported gesture sets grows.
+
 TinyMind provides a Mixture-of-Experts (MoE) layer family: a small **router**
 network scores the input against several **expert** sub-networks, and only the
 selected expert(s) run. The headline property for embedded targets is that

--- a/docs/architectures/quantized-networks.md
+++ b/docs/architectures/quantized-networks.md
@@ -7,6 +7,8 @@ nav_order: 4
 
 # Quantized Neural Networks
 
+> **Real-world use:** a sub-dollar microcontroller with no hardware multiplier runs an always-on wake-word detector. `BinaryDense` packs a 64-wide layer into 128 bytes and executes the MAC as XNOR + popcount, so a part that physically cannot multiply fast still spots the trigger phrase in real time.
+
 This page covers TinyMind's **extreme-quantization** layer types for ultra-low-power inference: `BinaryDense` and `TernaryDense`. For the more familiar **TFLite / CMSIS-NN style int8 affine quantization** path (per-tensor / per-channel `(scale, zero_point)`, int32 accumulators, integer Requantizer), see [Int8 Affine Quantization]({{ site.baseurl }}/architectures/int8-quantization). The two paths coexist; pick the binary / ternary route when you need 32x compression and a multiply-free MAC, pick the int8 route for drop-in MobileNet-shape deployment.
 
 `BinaryDense` and `TernaryDense` replace full-precision multiply-accumulate operations with bitwise logic (XNOR + popcount for binary) or conditional add/subtract/skip (for ternary), achieving massive memory reduction and eliminating multiplication entirely from the forward pass.

--- a/docs/architectures/self-attention.md
+++ b/docs/architectures/self-attention.md
@@ -7,6 +7,8 @@ nav_order: 5
 
 # Linear Self-Attention
 
+> **Real-world use:** a wearable gesture sensor fuses several IMU channels over a short motion window, learning which channel matters at each timestep. The ReLU-kernel linear attention does this at O(N) cost instead of the quadratic cost of softmax attention, so a Cortex-M0 keeps up at sensor rates with no exponential or division on the inference path.
+
 Tinymind provides `SelfAttention1D`, a standalone composable layer that implements linear self-attention for sequence processing. It uses a ReLU kernel feature map instead of softmax, reducing complexity from O(N^2 * D) to O(N * D * P + N * P^2) and eliminating the need for exponential or division operations -- making it practical for fixed-point targets.
 
 ## Why Linear Attention?

--- a/docs/architectures/simd-backends.md
+++ b/docs/architectures/simd-backends.md
@@ -7,6 +7,8 @@ nav_order: 7
 
 # SIMD Backends
 
+> **Real-world use:** one int8 keyword-spotter ships to two targets — a Cortex-M55 with Helium and an application-class core with NEON. A single `-march=` flag selects the matching SIMD path at build time; the `output_checksum` is identical to the scalar build, so the only thing that changes is throughput. The numerics never move.
+
 TinyMind ships ISA-capability-gated SIMD specializations in the inner reduction loop of the int8 affine layer family (`QDense`, `QConv2D`, `QConv2DPerChannel`). The library never sniffs the CPU. Every backend lives behind a `TINYMIND_ENABLE_SIMD_*` preprocessor gate, every gate defaults to `0`, and with all gates off the layer bodies fall back to a scalar dispatch that emits **byte-identical** output to the scalar reference.
 
 ![SIMD backend comparison]({{ site.baseurl }}/assets/plots/simd_backends.png)

--- a/docs/architectures/state-space.md
+++ b/docs/architectures/state-space.md
@@ -7,6 +7,8 @@ nav_order: 11
 
 # State-Space (S4-lite)
 
+> **Real-world use:** an always-on vibration monitor on a motor bearing flags a developing fault from a 4 kHz accelerometer stream. The diagonal recurrence summarizes the entire history in a fixed-size state, so the per-step cost and memory are the same after a month of runtime as after the first second — the right shape for a sensor that never stops streaming.
+
 TinyMind provides a diagonal **state-space** layer family — a linear-recurrent
 sequence model (S4-lite / linear RNN) that processes a stream one timestep at a
 time with a fixed-size state. It is the structured-sequence cousin of the

--- a/docs/architectures/transformer-decoder.md
+++ b/docs/architectures/transformer-decoder.md
@@ -7,6 +7,8 @@ nav_order: 10
 
 # Transformer Decoder (seq2seq)
 
+> **Real-world use:** an offline voice-command device turns a recognized phrase into a structured control sequence ("set thermostat to 21 and arm the alarm"). The decoder generates the output tokens autoregressively against a fixed-size KV state, so memory stays flat no matter how long the command — the whole sequence-to-sequence step runs on-device with nothing sent off-chip.
+
 TinyMind's encoder layers (linear / softmax self-attention, embedding,
 positional encoding) produce a memory tensor. The **decoder** family consumes
 it, completing an int8 encoder-decoder (seq2seq) transformer. It adds three


### PR DESCRIPTION
## What

Adds a top-of-page **Real-world use** callout to each of the 13 architecture pages, directly under the H1 and before the tables.

Each callout is one concrete deployed scenario tying the model/technique to a real embedded use case — the reader sees "why care" before any API detail.

| Page | Scenario |
|---|---|
| LSTM & GRU | wrist sleep-stage tracker, 808-byte GRU, no cloud |
| KAN | on-device soft sensor replacing a calibration LUT |
| Conv & Pooling | coin-cell fall detector, Conv1D→MaxPool1D |
| Quantized Networks | wake-word on multiplier-less MCU via XNOR+popcount |
| Int8 Affine | PyTorch MobileNet → Cortex-M, pure-integer |
| FFT | bearing fault-frequency monitor |
| SIMD Backends | one int8 binary, two ISAs, checksum identical |
| Mixed Precision | doorbell cam int8→fp16→int8 handoff |
| Mixture of Experts | gesture hub, top-1 router, flat compute |
| Transformer Decoder | offline voice command → control sequence, flat KV |
| Self-Attention | IMU gesture fusion at O(N) on M0 |
| State-Space | always-on bearing vibration, fixed state any length |
| Decision Trees | pump controller, integer compares only |

Docs-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)