### PR TITLE
docs(pages): set og:image to TinyMind logo for link previews

### DIFF
--- a/docs/_includes/head_custom.html
+++ b/docs/_includes/head_custom.html
@@ -1,0 +1,8 @@
+<!-- Social-preview (Open Graph / Twitter) image so link unfurls show the TinyMind
+     logo deterministically instead of an arbitrary page image. -->
+<meta property="og:image" content="{{ site.url }}{{ site.baseurl }}/assets/tinymind_logo.png" />
+<meta property="og:image:width" content="200" />
+<meta property="og:image:height" content="200" />
+<meta property="og:image:alt" content="TinyMind logo" />
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:image" content="{{ site.url }}{{ site.baseurl }}/assets/tinymind_logo.png" />


### PR DESCRIPTION
## What

Adds `docs/_includes/head_custom.html` declaring the TinyMind logo as the Open Graph / Twitter social-preview image.

## Why

The Pages site set no `og:image`, so LinkedIn (and other scrapers) picked an arbitrary page image when unfurling https://danmcleran.github.io/tinymind/ — surfacing an old gallery heatmap instead of the brand logo. `head_custom.html` is the just-the-docs head extension point, so the tags inject into every page `<head>` with no theme fork.

The logo is 200x200, so `twitter:card` is `summary` (square thumbnail). A dedicated 1200x630 banner can replace it later for a full-width card.

## Verify

After merge + Pages rebuild, run the URL through the LinkedIn Post Inspector to force a re-scrape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)