### PR TITLE
docs(pages): lengthen site description past 100 chars for link previews

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,6 @@
 theme: just-the-docs
 title: TinyMind
-description: Header-only C++ template library for neural networks on embedded systems
+description: "Header-only C++ template library for neural networks and Q-learning on embedded systems: int8 and fixed-point inference with no FPU, heap, or operating system required."
 logo: "/assets/tinymind_logo.png"
 baseurl: "/tinymind"
 url: "https://danmcleran.github.io"


### PR DESCRIPTION
## What

Expands the `description` in `docs/_config.yml` past 100 characters.

## Why

The LinkedIn Post Inspector warns when `og:description` is under 100 chars. The old tagline was ~70. The new one (168 chars) clears the warning and gives social-preview cards a fuller summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)