### PR TITLE
feat(layers): add Upsample1D (nearest + linear)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ These layers sit outside the neural network template and can be chained into pip
 
 - **`conv1d.hpp`** — 1D convolution layer for time-series feature extraction.
 - **`pool1d.hpp`** — `MaxPool1D` and `AvgPool1D` for downsampling.
+- **`upsample1d.hpp`** — `UpsampleNearest1D` (repeat; no arithmetic, holds at `FLOAT=0`/`STD=0`) and `UpsampleLinear1D` (interpolated; QValue/float arithmetic) for integer-factor upsampling. The decoder-side counterpart to `pool1d.hpp`; a cheap, checkerboard-free alternative to a transposed convolution.
 - **`conv2d.hpp`** — 2D convolution for spectrograms/images, NHWC layout, VALID padding.
 - **`depthwiseconv2d.hpp`** / **`pointwiseconv2d.hpp`** — MobileNet-style depthwise-separable blocks.
 - **`pool2d.hpp`** — `MaxPool2D`, `AvgPool2D`, and `GlobalAvgPool2D` (GAP replaces the big flatten-to-dense matrix).

--- a/cpp/upsample1d.hpp
+++ b/cpp/upsample1d.hpp
@@ -1,0 +1,260 @@
+/**
+* Copyright (c) 2026 Dan McLeran
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#pragma once
+
+#include "include/tinymind_traits.hpp"
+
+#include <cstddef>
+
+namespace tinymind {
+    /**
+     * 1D nearest-neighbour upsampling layer.
+     *
+     * Grows a sequence by an integer factor, repeating each input element
+     * ScaleFactor times. The transpose (decoder) counterpart to MaxPool1D /
+     * AvgPool1D in encoder-decoder pipelines (1D autoencoders, U-Net-1D
+     * segmentation, denoising) where the decoder must restore the original
+     * time resolution:
+     *   Conv1D -> Pool1D -> ... -> Upsample1D -> Conv1D
+     *
+     * A cheaper, artifact-free alternative to a transposed convolution
+     * (Upsample + Conv1D avoids the checkerboard patterns learned upsampling
+     * can introduce). Uses no arithmetic, so it holds for every ValueType at
+     * TINYMIND_ENABLE_FLOAT=0 / STD=0.
+     *
+     * All dimensions are compile-time template parameters with zero dynamic
+     * allocation. Layout is channel-major, matching Conv1D / Pool1D:
+     * [ch0_t0, ch0_t1, ..., ch1_t0, ch1_t1, ...].
+     *
+     * @tparam ValueType     Numeric type (QValue or float/double)
+     * @tparam InputLength   Number of input elements per channel
+     * @tparam ScaleFactor   Integer upsampling factor (output length = InputLength * ScaleFactor)
+     * @tparam NumChannels   Number of input channels (default 1)
+     */
+    template<
+        typename ValueType,
+        size_t InputLength,
+        size_t ScaleFactor,
+        size_t NumChannels = 1>
+    class UpsampleNearest1D
+    {
+    public:
+        static const size_t OutputLength = InputLength * ScaleFactor;
+        static const size_t OutputSize = NumChannels * OutputLength;
+        static const size_t InputSize = NumChannels * InputLength;
+
+        /**
+         * Forward pass: repeat each input element ScaleFactor times.
+         *
+         * @param input  Array of InputSize values (channel-major layout)
+         * @param output Array of OutputSize values (channel-major layout)
+         */
+        void forward(ValueType const* const input, ValueType* output) const
+        {
+            for (size_t ch = 0; ch < NumChannels; ++ch)
+            {
+                const size_t inputOffset = ch * InputLength;
+                const size_t outputOffset = ch * OutputLength;
+
+                for (size_t i = 0; i < InputLength; ++i)
+                {
+                    const ValueType value = input[inputOffset + i];
+
+                    for (size_t k = 0; k < ScaleFactor; ++k)
+                    {
+                        output[outputOffset + i * ScaleFactor + k] = value;
+                    }
+                }
+            }
+        }
+
+        /**
+         * Backward pass: accumulate the gradients of the ScaleFactor outputs
+         * that each input element produced back onto that element.
+         *
+         * @param outputDeltas Array of OutputSize gradient values
+         * @param inputDeltas  Array of InputSize gradient values (zeroed then populated)
+         */
+        void backward(ValueType const* const outputDeltas, ValueType* inputDeltas) const
+        {
+            for (size_t ch = 0; ch < NumChannels; ++ch)
+            {
+                const size_t inputOffset = ch * InputLength;
+                const size_t outputOffset = ch * OutputLength;
+
+                for (size_t i = 0; i < InputLength; ++i)
+                {
+                    ValueType sum = ValueType(0);
+
+                    for (size_t k = 0; k < ScaleFactor; ++k)
+                    {
+                        sum += outputDeltas[outputOffset + i * ScaleFactor + k];
+                    }
+
+                    inputDeltas[inputOffset + i] = sum;
+                }
+            }
+        }
+
+    private:
+        static_assert(InputLength > 0, "Input length must be > 0.");
+        static_assert(ScaleFactor > 0, "Scale factor must be > 0.");
+        static_assert(NumChannels > 0, "Number of channels must be > 0.");
+    };
+
+    /**
+     * 1D linear-interpolation upsampling layer.
+     *
+     * Grows a sequence by an integer factor, filling the gaps with a straight
+     * ramp between neighbouring input elements instead of repeating them.
+     * Input element k lands exactly on output index k * ScaleFactor; the
+     * ScaleFactor-1 outputs between two input nodes are their weighted blend.
+     * The tail beyond the last input node holds the last value (edge clamp),
+     * so the output length stays InputLength * ScaleFactor.
+     *
+     * Smoother than UpsampleNearest1D at the cost of a multiply per output
+     * element; requires ValueType arithmetic (QValue or float/double), the
+     * same class of type Conv1D / AvgPool1D operate on.
+     *
+     * @tparam ValueType     Numeric type (QValue or float/double)
+     * @tparam InputLength   Number of input elements per channel
+     * @tparam ScaleFactor   Integer upsampling factor (output length = InputLength * ScaleFactor)
+     * @tparam NumChannels   Number of input channels (default 1)
+     */
+    template<
+        typename ValueType,
+        size_t InputLength,
+        size_t ScaleFactor,
+        size_t NumChannels = 1>
+    class UpsampleLinear1D
+    {
+    public:
+        static const size_t OutputLength = InputLength * ScaleFactor;
+        static const size_t OutputSize = NumChannels * OutputLength;
+        static const size_t InputSize = NumChannels * InputLength;
+
+        /**
+         * Forward pass: linearly interpolate between neighbouring input nodes.
+         *
+         * output[o] = input[i0] + (input[i1] - input[i0]) * (k / ScaleFactor)
+         * where i0 = o / ScaleFactor, k = o % ScaleFactor, and i1 is i0 + 1
+         * clamped to the last input element.
+         *
+         * @param input  Array of InputSize values (channel-major layout)
+         * @param output Array of OutputSize values (channel-major layout)
+         */
+        void forward(ValueType const* const input, ValueType* output) const
+        {
+            for (size_t ch = 0; ch < NumChannels; ++ch)
+            {
+                const size_t inputOffset = ch * InputLength;
+                const size_t outputOffset = ch * OutputLength;
+
+                for (size_t o = 0; o < OutputLength; ++o)
+                {
+                    const size_t i0 = o / ScaleFactor;
+                    const size_t k = o % ScaleFactor;
+                    const size_t i1 = (i0 + 1 < InputLength) ? (i0 + 1) : i0;
+
+                    const ValueType lo = input[inputOffset + i0];
+                    const ValueType hi = input[inputOffset + i1];
+
+                    output[outputOffset + o] = lo + (hi - lo) * weight(k);
+                }
+            }
+        }
+
+        /**
+         * Backward pass: split each output gradient between the two input
+         * nodes it interpolated, by the same weights used in the forward pass
+         * (the transpose of forward).
+         *
+         * @param outputDeltas Array of OutputSize gradient values
+         * @param inputDeltas  Array of InputSize gradient values (zeroed then populated)
+         */
+        void backward(ValueType const* const outputDeltas, ValueType* inputDeltas) const
+        {
+            for (size_t i = 0; i < InputSize; ++i)
+            {
+                inputDeltas[i] = ValueType(0);
+            }
+
+            for (size_t ch = 0; ch < NumChannels; ++ch)
+            {
+                const size_t inputOffset = ch * InputLength;
+                const size_t outputOffset = ch * OutputLength;
+
+                for (size_t o = 0; o < OutputLength; ++o)
+                {
+                    const size_t i0 = o / ScaleFactor;
+                    const size_t k = o % ScaleFactor;
+                    const size_t i1 = (i0 + 1 < InputLength) ? (i0 + 1) : i0;
+
+                    const ValueType w = weight(k);
+                    const ValueType grad = outputDeltas[outputOffset + o];
+
+                    inputDeltas[inputOffset + i0] += grad * (one() - w);
+                    inputDeltas[inputOffset + i1] += grad * w;
+                }
+            }
+        }
+
+    private:
+        // Interpolation weight k / ScaleFactor as ValueType. For floating-point
+        // a cast is enough; for QValue the (FixedPart, FractionalPart)
+        // constructor is required because QValue(int) treats its argument as
+        // raw bits -- so the whole numbers are built first, then divided.
+        template<typename T = ValueType>
+        static typename tinymind::enable_if<tinymind::is_floating_point<T>::value, T>::type
+        weight(const size_t k)
+        {
+            return static_cast<T>(k) / static_cast<T>(ScaleFactor);
+        }
+
+        template<typename T = ValueType>
+        static typename tinymind::enable_if<!tinymind::is_floating_point<T>::value, T>::type
+        weight(const size_t k)
+        {
+            return T(static_cast<typename T::FixedPartFieldType>(k), 0u) /
+                   T(static_cast<typename T::FixedPartFieldType>(ScaleFactor), 0u);
+        }
+
+        template<typename T = ValueType>
+        static typename tinymind::enable_if<tinymind::is_floating_point<T>::value, T>::type
+        one()
+        {
+            return static_cast<T>(1);
+        }
+
+        template<typename T = ValueType>
+        static typename tinymind::enable_if<!tinymind::is_floating_point<T>::value, T>::type
+        one()
+        {
+            return T(static_cast<typename T::FixedPartFieldType>(1), 0u);
+        }
+
+        static_assert(InputLength > 0, "Input length must be > 0.");
+        static_assert(ScaleFactor > 0, "Scale factor must be > 0.");
+        static_assert(NumChannels > 0, "Number of channels must be > 0.");
+    };
+}

--- a/unit_test/embedded/embedded_smoke_test.cpp
+++ b/unit_test/embedded/embedded_smoke_test.cpp
@@ -58,6 +58,7 @@
 #include "dual.hpp"
 #include "conv1d.hpp"
 #include "pool1d.hpp"
+#include "upsample1d.hpp"
 #include "conv2d.hpp"
 #include "depthwiseconv2d.hpp"
 #include "pointwiseconv2d.hpp"
@@ -122,6 +123,11 @@ typedef tinymind::QValue<8, 8, true> Q88;
 // 1D pipeline.
 typedef tinymind::Conv1D<Q88, 16, 3, 1, 4> Conv1Type;       // 16 -> 14, 4 filters
 typedef tinymind::MaxPool1D<Q88, Conv1Type::OutputLength, 2, 2, 4> Pool1Type;
+// Decoder-side upsampling: restore the pooled length. Nearest exercises the
+// no-arithmetic path (holds at FLOAT=0/STD=0); Linear exercises the QValue
+// arithmetic path.
+typedef tinymind::UpsampleNearest1D<Q88, Pool1Type::OutputLength, 2, 4> UpNearest1Type;
+typedef tinymind::UpsampleLinear1D<Q88, Pool1Type::OutputLength, 2, 4> UpLinear1Type;
 
 // 2D pipeline.
 typedef tinymind::Conv2D<Q88, 8, 8, 1, 3, 3, 1, 1, 2> Conv2Type;
@@ -138,6 +144,8 @@ typedef tinymind::SelfAttention1D<Q88, 4, 4, 4> AttType;
 Q88 input1d[16];
 Q88 conv1Out[Conv1Type::OutputSize];
 Q88 pool1Out[Pool1Type::OutputSize];
+Q88 upNearest1Out[UpNearest1Type::OutputSize];
+Q88 upLinear1Out[UpLinear1Type::OutputSize];
 
 Q88 input2d[8 * 8];
 Q88 conv2Out[Conv2Type::OutputSize];
@@ -153,6 +161,8 @@ Q88 attOut[AttType::OutputSize];
 
 Conv1Type gConv1;
 Pool1Type gPool1;
+UpNearest1Type gUpNearest1;
+UpLinear1Type gUpLinear1;
 Conv2Type gConv2;
 Pool2Type gPool2;
 DwType    gDw;
@@ -884,6 +894,8 @@ int main()
 
     gConv1.forward(input1d, conv1Out);
     gPool1.forward(conv1Out, pool1Out);
+    gUpNearest1.forward(pool1Out, upNearest1Out);
+    gUpLinear1.forward(pool1Out, upLinear1Out);
 
     gConv2.forward(input2d, conv2Out);
     gPool2.forward(conv2Out, pool2Out);

--- a/unit_test/nn/nn_unit_test.cpp
+++ b/unit_test/nn/nn_unit_test.cpp
@@ -48,6 +48,7 @@ TINYMIND_DISABLE_WARNING_POP
 #include "truncatedBPTT.hpp"
 #include "conv1d.hpp"
 #include "pool1d.hpp"
+#include "upsample1d.hpp"
 #include "conv2d.hpp"
 #include "depthwiseconv2d.hpp"
 #include "pointwiseconv2d.hpp"
@@ -4787,6 +4788,153 @@ BOOST_AUTO_TEST_CASE(test_case_avgpool1d_fixed_point)
     // (2+4)/2 = 3.0; (6+8)/2 = 7.0.
     BOOST_TEST(output[0].getValue() == ValueType(3, 0).getValue());
     BOOST_TEST(output[1].getValue() == ValueType(7, 0).getValue());
+}
+
+// ============================================================
+// UpsampleNearest1D tests
+// ============================================================
+
+BOOST_AUTO_TEST_CASE(test_case_upsample_nearest1d_forward)
+{
+    // Repeat each element by factor 2: dual of a stride-2 pool.
+    tinymind::UpsampleNearest1D<double, 4, 2, 1> up;
+
+    double input[4] = {3.0, 7.0, 2.0, 9.0};
+    double output[8]; // 4 * 2
+
+    up.forward(input, output);
+
+    const double expected[8] = {3.0, 3.0, 7.0, 7.0, 2.0, 2.0, 9.0, 9.0};
+    for (size_t i = 0; i < 8; ++i)
+    {
+        BOOST_TEST(fabs(output[i] - expected[i]) < 0.001);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_case_upsample_nearest1d_backward)
+{
+    // Backward accumulates the ScaleFactor output grads onto each input.
+    tinymind::UpsampleNearest1D<double, 3, 3, 1> up;
+
+    double outputDeltas[9] = {0.1, 0.2, 0.3, 1.0, 1.0, 1.0, 0.5, 0.0, -0.5};
+    double inputDeltas[3];
+    up.backward(outputDeltas, inputDeltas);
+
+    BOOST_TEST(fabs(inputDeltas[0] - 0.6) < 0.001); // 0.1+0.2+0.3
+    BOOST_TEST(fabs(inputDeltas[1] - 3.0) < 0.001); // 1+1+1
+    BOOST_TEST(fabs(inputDeltas[2] - 0.0) < 0.001); // 0.5+0-0.5
+}
+
+BOOST_AUTO_TEST_CASE(test_case_upsample_nearest1d_multichannel)
+{
+    // 2 channels, 3 elements each, factor 2, channel-major.
+    tinymind::UpsampleNearest1D<double, 3, 2, 2> up;
+
+    double input[6] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+    double output[12];
+    up.forward(input, output);
+
+    const double expected[12] = {1.0, 1.0, 2.0, 2.0, 3.0, 3.0,
+                                 4.0, 4.0, 5.0, 5.0, 6.0, 6.0};
+    for (size_t i = 0; i < 12; ++i)
+    {
+        BOOST_TEST(fabs(output[i] - expected[i]) < 0.001);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_case_upsample_nearest1d_static_sizes)
+{
+    typedef tinymind::UpsampleNearest1D<double, 50, 4, 3> UpType;
+
+    static_assert(UpType::OutputLength == 200, "Wrong output length"); // 50 * 4
+    static_assert(UpType::OutputSize == 600, "Wrong output size");     // 3 * 200
+    static_assert(UpType::InputSize == 150, "Wrong input size");       // 3 * 50
+    BOOST_TEST(true);
+}
+
+BOOST_AUTO_TEST_CASE(test_case_upsample_nearest1d_fixed_point)
+{
+    // No arithmetic: exact bit copies in Q8.8.
+    typedef tinymind::QValue<8, 8, true, tinymind::RoundUpPolicy> ValueType;
+    tinymind::UpsampleNearest1D<ValueType, 2, 3, 1> up;
+
+    ValueType input[2] = {ValueType(3, 0), ValueType(5, 0)};
+    ValueType output[6];
+    up.forward(input, output);
+
+    BOOST_TEST(output[0].getValue() == ValueType(3, 0).getValue());
+    BOOST_TEST(output[1].getValue() == ValueType(3, 0).getValue());
+    BOOST_TEST(output[2].getValue() == ValueType(3, 0).getValue());
+    BOOST_TEST(output[3].getValue() == ValueType(5, 0).getValue());
+    BOOST_TEST(output[4].getValue() == ValueType(5, 0).getValue());
+    BOOST_TEST(output[5].getValue() == ValueType(5, 0).getValue());
+}
+
+// ============================================================
+// UpsampleLinear1D tests
+// ============================================================
+
+BOOST_AUTO_TEST_CASE(test_case_upsample_linear1d_forward)
+{
+    // Factor 2: input nodes land on even outputs; odds are the midpoints.
+    tinymind::UpsampleLinear1D<double, 4, 2, 1> up;
+
+    double input[4] = {0.0, 4.0, 2.0, 10.0};
+    double output[8];
+    up.forward(input, output);
+
+    // node, mid, node, mid, node, mid, node, tail-clamped last value
+    const double expected[8] = {0.0, 2.0, 4.0, 3.0, 2.0, 6.0, 10.0, 10.0};
+    for (size_t i = 0; i < 8; ++i)
+    {
+        BOOST_TEST(fabs(output[i] - expected[i]) < 0.001);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_case_upsample_linear1d_nodes_preserved)
+{
+    // Every input element must reappear exactly at index k * ScaleFactor.
+    tinymind::UpsampleLinear1D<double, 5, 3, 1> up;
+
+    double input[5] = {1.0, 2.0, 4.0, 8.0, 16.0};
+    double output[15];
+    up.forward(input, output);
+
+    for (size_t k = 0; k < 5; ++k)
+    {
+        BOOST_TEST(fabs(output[k * 3] - input[k]) < 0.001);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_case_upsample_linear1d_backward)
+{
+    // Backward is the transpose: a unit grad on a midpoint splits by weight.
+    tinymind::UpsampleLinear1D<double, 2, 2, 1> up;
+
+    // outputs: [node0, mid, node1, tail]; mid weight = 0.5 to each node.
+    double outputDeltas[4] = {0.0, 1.0, 0.0, 0.0};
+    double inputDeltas[2];
+    up.backward(outputDeltas, inputDeltas);
+
+    BOOST_TEST(fabs(inputDeltas[0] - 0.5) < 0.001);
+    BOOST_TEST(fabs(inputDeltas[1] - 0.5) < 0.001);
+}
+
+BOOST_AUTO_TEST_CASE(test_case_upsample_linear1d_fixed_point)
+{
+    // Midpoint of [2.0, 6.0] in Q8.8 must be exactly 4.0 (weight 0.5 built via
+    // the (FixedPart, FractionalPart) constructor, not raw bits).
+    typedef tinymind::QValue<8, 8, true, tinymind::RoundUpPolicy> ValueType;
+    tinymind::UpsampleLinear1D<ValueType, 2, 2, 1> up;
+
+    ValueType input[2] = {ValueType(2, 0), ValueType(6, 0)};
+    ValueType output[4];
+    up.forward(input, output);
+
+    BOOST_TEST(output[0].getValue() == ValueType(2, 0).getValue()); // node
+    BOOST_TEST(output[1].getValue() == ValueType(4, 0).getValue()); // midpoint
+    BOOST_TEST(output[2].getValue() == ValueType(6, 0).getValue()); // node
+    BOOST_TEST(output[3].getValue() == ValueType(6, 0).getValue()); // tail clamp
 }
 
 // ============================================================


### PR DESCRIPTION
Adds `cpp/upsample1d.hpp` — two integer-factor 1D upsampling layers, the decoder-side counterpart to `pool1d.hpp`. Enables encoder-decoder pipelines on-device (1D autoencoders for anomaly detection, U-Net-1D segmentation/denoising, TTS/vocoder upsampling) and is a cheap, checkerboard-free alternative to a transposed convolution (`Upsample + Conv1D`).

## Layers
- **`UpsampleNearest1D`** — repeats each element `ScaleFactor` times. No arithmetic → holds for every `ValueType` at `TINYMIND_ENABLE_FLOAT=0`/`STD=0`.
- **`UpsampleLinear1D`** — linear interpolation between input nodes; input element `k` lands exactly on output `k*ScaleFactor`, tail edge-clamped. One multiply per output. Fixed-point weight built via the `(FixedPart, FractionalPart)` constructor, mirroring `AvgPool1D::divisor()`.

Both expose `forward` + `backward` (transpose) and match the channel-major layout of `Conv1D`/`Pool1D`. Compile-time sizes, zero dynamic allocation.

## Tests & coverage
- 9 Boost cases in `unit_test/nn` — forward, backward, multichannel, static sizes, Q8.8 exactness (incl. midpoint of [2,6] = exactly 4.0, node preservation, tail clamp).
- Wired into the embedded smoke pipeline → both variants covered by the freestanding `(FLOAT,STD,...)` matrix, the **ARM cross-compile** gate (M0+/M4/M33), and the **heap-free** gate.
- Passes the header self-containment hard gate (140/0). Stack frames negligible.

Verified locally: `nn` suite green, full embedded matrix builds+runs, `arm_crosscompile` + `heapfree` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)