### PR TITLE
ci: retry apt-get installs to survive transient runner failures

### DIFF
--- a/.github/actions/apt-install/action.yml
+++ b/.github/actions/apt-install/action.yml
@@ -1,0 +1,38 @@
+name: apt-install
+description: >
+  apt-get update + install with retries. GitHub-hosted runners intermittently
+  hit transient apt mirror/network failures (exit 100) at the install step,
+  which fail an otherwise-green job and send a false-alarm failure email. This
+  retries update+install a few times with linear backoff before giving up.
+
+inputs:
+  packages:
+    description: Space-separated list of apt packages to install.
+    required: true
+  attempts:
+    description: Maximum number of attempts before failing.
+    required: false
+    default: "5"
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -uo pipefail
+        packages="${{ inputs.packages }}"
+        max="${{ inputs.attempts }}"
+        for attempt in $(seq 1 "$max"); do
+          if sudo apt-get update && sudo apt-get install -y $packages; then
+            echo "apt-install: '$packages' succeeded on attempt $attempt"
+            exit 0
+          fi
+          if [ "$attempt" -lt "$max" ]; then
+            wait=$((attempt * 10))
+            echo "apt-install: attempt $attempt/$max failed; cleaning and retrying in ${wait}s" >&2
+            sudo apt-get clean || true
+            sleep "$wait"
+          fi
+        done
+        echo "apt-install: '$packages' failed after $max attempts" >&2
+        exit 1

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -61,7 +61,9 @@ jobs:
         if: needs.changes.outputs.code == 'true'
       - name: Install Boost
         if: needs.changes.outputs.code == 'true'
-        run: sudo apt-get update && sudo apt-get install -y libboost-dev libboost-test-dev
+        uses: ./.github/actions/apt-install
+        with:
+          packages: libboost-dev libboost-test-dev
       - name: Build and run all runtime suites + int8 examples under ASan/UBSan
         if: needs.changes.outputs.code == 'true'
         env:
@@ -82,7 +84,9 @@ jobs:
         if: needs.changes.outputs.code == 'true'
       - name: Install Boost
         if: needs.changes.outputs.code == 'true'
-        run: sudo apt-get update && sudo apt-get install -y libboost-dev libboost-test-dev
+        uses: ./.github/actions/apt-install
+        with:
+          packages: libboost-dev libboost-test-dev
       - name: Build and run dispatch-consumer suites with AVX2 under ASan/UBSan
         if: needs.changes.outputs.code == 'true'
         env:
@@ -103,7 +107,9 @@ jobs:
         if: needs.changes.outputs.code == 'true'
       - name: Install toolchain
         if: needs.changes.outputs.code == 'true'
-        run: sudo apt-get update && sudo apt-get install -y clang libomp-dev libboost-dev libboost-test-dev
+        uses: ./.github/actions/apt-install
+        with:
+          packages: clang libomp-dev libboost-dev libboost-test-dev
       - name: Build and run OpenMP-enabled suites under TSan
         if: needs.changes.outputs.code == 'true'
         env:
@@ -119,7 +125,9 @@ jobs:
         if: needs.changes.outputs.code == 'true'
       - name: Install cppcheck
         if: needs.changes.outputs.code == 'true'
-        run: sudo apt-get update && sudo apt-get install -y cppcheck
+        uses: ./.github/actions/apt-install
+        with:
+          packages: cppcheck
       - name: cppcheck (warning + portability)
         if: needs.changes.outputs.code == 'true'
         run: make cppcheck
@@ -133,7 +141,9 @@ jobs:
         if: needs.changes.outputs.code == 'true'
       - name: Install Boost + lcov
         if: needs.changes.outputs.code == 'true'
-        run: sudo apt-get update && sudo apt-get install -y libboost-dev libboost-test-dev lcov
+        uses: ./.github/actions/apt-install
+        with:
+          packages: libboost-dev libboost-test-dev lcov
       - name: Capture coverage and enforce floor
         if: needs.changes.outputs.code == 'true'
         env:
@@ -160,7 +170,9 @@ jobs:
         if: needs.changes.outputs.code == 'true'
       - name: Install Clang
         if: needs.changes.outputs.code == 'true'
-        run: sudo apt-get update && sudo apt-get install -y clang
+        uses: ./.github/actions/apt-install
+        with:
+          packages: clang
       - name: Replay committed corpus (ASan+UBSan)
         if: needs.changes.outputs.code == 'true'
         run: make -C fuzz replay FUZZ_CXX=clang++
@@ -174,7 +186,9 @@ jobs:
         if: needs.changes.outputs.code == 'true'
       - name: Install CBMC
         if: needs.changes.outputs.code == 'true'
-        run: sudo apt-get update && sudo apt-get install -y cbmc
+        uses: ./.github/actions/apt-install
+        with:
+          packages: cbmc
       - name: Prove fixed-point kernels
         if: needs.changes.outputs.code == 'true'
         run: make -C formal prove
@@ -191,7 +205,9 @@ jobs:
         if: needs.changes.outputs.code == 'true'
       - name: Install cppcheck
         if: needs.changes.outputs.code == 'true'
-        run: sudo apt-get update && sudo apt-get install -y cppcheck
+        uses: ./.github/actions/apt-install
+        with:
+          packages: cppcheck
       - name: MISRA C:2012 addon
         if: needs.changes.outputs.code == 'true'
         run: make misra
@@ -215,7 +231,9 @@ jobs:
         if: needs.changes.outputs.code == 'true'
       - name: Install toolchain
         if: needs.changes.outputs.code == 'true'
-        run: sudo apt-get update && sudo apt-get install -y libboost-dev libboost-test-dev clang-tidy bear
+        uses: ./.github/actions/apt-install
+        with:
+          packages: libboost-dev libboost-test-dev clang-tidy bear
       - name: clang-tidy
         if: needs.changes.outputs.code == 'true'
         env:
@@ -243,7 +261,9 @@ jobs:
         if: needs.changes.outputs.code == 'true'
       - name: Install arm-none-eabi toolchain
         if: needs.changes.outputs.code == 'true'
-        run: sudo apt-get update && sudo apt-get install -y gcc-arm-none-eabi
+        uses: ./.github/actions/apt-install
+        with:
+          packages: gcc-arm-none-eabi
       - name: Cross-compile smoke corners for Cortex-M
         if: needs.changes.outputs.code == 'true'
         run: make -C unit_test/embedded arm_crosscompile
@@ -311,7 +331,9 @@ jobs:
         if: needs.changes.outputs.code == 'true'
       - name: Install arm-none-eabi toolchain
         if: needs.changes.outputs.code == 'true'
-        run: sudo apt-get update && sudo apt-get install -y gcc-arm-none-eabi
+        uses: ./.github/actions/apt-install
+        with:
+          packages: gcc-arm-none-eabi
       - name: Report deepest stack frames
         if: needs.changes.outputs.code == 'true'
         run: make -C unit_test/embedded stack_usage

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,7 +58,9 @@ jobs:
 
       - name: Install Boost
         if: needs.changes.outputs.code == 'true'
-        run: sudo apt-get update && sudo apt-get install -y libboost-dev libboost-test-dev
+        uses: ./.github/actions/apt-install
+        with:
+          packages: libboost-dev libboost-test-dev
 
       - name: Initialize CodeQL
         if: needs.changes.outputs.code == 'true'

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -44,7 +44,9 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install Clang
-        run: sudo apt-get update && sudo apt-get install -y clang
+        uses: ./.github/actions/apt-install
+        with:
+          packages: clang
       - name: Derive kernel name
         id: kernel
         run: |


### PR DESCRIPTION
GitHub-hosted runners intermittently fail `apt-get` at the install step (exit 100) on a transient mirror/network hiccup. That fails an otherwise-green job and sends a false-alarm failure email — seen twice now (cppcheck / ARM cross-compile / clang-tidy / stack-usage), each cleared by a plain rerun with no code change.

## Change
- New composite action `.github/actions/apt-install`: wraps `apt-get update && install` in a retry loop (5 attempts, linear backoff, `apt-get clean` between tries).
- All **13** install steps across `analysis.yml`, `codeql.yml`, `fuzz-nightly.yml` routed through it.
- Package sets and the docs-only `if:` guards unchanged — only transient-failure handling is new.

## Verified
- Retry loop logic unit-tested locally (fails twice → succeeds 3rd → exit 0; exhausts → exit 1).
- All workflow + action YAML valid.
- This PR touches workflows → full gate run exercises the composite action in real CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)