### PR TITLE
docs: correct how the PINN example computes its weight gradients

### DIFF
--- a/docs/examples/pinn_heat1d.md
+++ b/docs/examples/pinn_heat1d.md
@@ -12,7 +12,8 @@ A physics-informed neural network that learns the 1-D heat equation `u_t = nu * 
 ## How it works
 
 - A `PinnMlp<2, 12, 1>` field `u(x, t)`: a single-hidden-layer tanh MLP with 12 units, from `cpp/pinn.hpp`. The autodiff and training paths run in `double` with `std::tanh`; the deployment residual benchmark runs the same field in Q16.16 fixed point (`QValue<16, 16>`) using the tanh lookup table (`TINYMIND_USE_TANH_16_16`).
-- Demonstrates differentiating the network with respect to its input coordinates: `u_t` via a first-order dual and `u_xx` via a nested second-order dual, the exact derivatives a PDE residual needs and that weight-gradient backprop cannot supply. Weight gradients during training come from finite differences over the exact-autodiff residual.
+- Demonstrates differentiating the network with respect to its input coordinates: `u_t` via a first-order dual and `u_xx` via a nested second-order dual, the exact derivatives a PDE residual needs and that weight-gradient backprop cannot supply.
+- Training is exact on both sides. The residual comes from the nested duals above, and the loss gradient with respect to all 49 weights is obtained in **one forward pass** by vector forward-mode (`MultiDual<V, N>`) inside `tinymind::pinn::sgdStep` — no finite differences anywhere in the training loop. Finite differences appear in this example only as an independent *reference* for checking the input derivatives (see the autodiff-vs-FD check below).
 - The residual is enforced on an interior collocation grid over `x` in `[0, 1]`, `t` in `[0, T]`, with the analytic reference `u(x, t) = exp(-nu*pi^2*t) * sin(pi*x)`. After training, the residual is recomputed in fixed point so the int8/fixed-point error against the double residual is bounded, giving a fixed-point residual-accuracy benchmark.
 
 ## Build and run
@@ -25,6 +26,27 @@ make plot      # needs matplotlib; a venv/pyenv works if it is not already in yo
 ```
 
 `make run` runs the verification checks (exact-solution residual, autodiff vs central finite differences, fixed-point residual benchmark). To produce the data `plot.py` reads, run the host-side training loop first with `make train` (built `-O3`, ~thousands of epochs but under a second), which writes `pinn_loss.csv` (residual loss and solution L2 error per epoch) and `pinn_solution.csv` (learned vs analytic field at two times). The fixed-point inference path pulls in `lookupTables.cpp` for the Q16.16 tanh table.
+
+## Results
+
+`make run` (verification):
+
+| check | measured |
+|---|---|
+| residual on a field with a closed form | 0.000e+00 |
+| `u_x` vs central finite differences | 9.207e-11 |
+| `u_t` vs central finite differences | 3.753e-11 |
+| `u_xx` vs central finite differences | 3.263e-06 (finite-difference round-off, ~eps/h², not autodiff error) |
+| Q16.16 vs float inference | 1.655e-03 |
+
+`make train` (8000 epochs, `PinnMlp 2->12->1`, 49 parameters):
+
+| | start | end |
+|---|---|---|
+| residual loss | 4.3726e+00 | 2.0989e-02 (208x lower) |
+| solution L2 error | 4.7870e-01 | 1.2615e-02 |
+
+Recomputing the trained residual in Q16.16 stays within 8.776e-03 of the double version.
 
 ## Output
 

--- a/docs/pinn-feasibility.md
+++ b/docs/pinn-feasibility.md
@@ -61,11 +61,11 @@ respect to its inputs.
 | Smooth activation (C² or better) | **Present** | `tanh`, `sigmoid`, `ELU`, `GELU` with analytic derivatives; `tanh(Dual)`/`sigmoid(Dual)` overloads in `cpp/dualActivations.hpp`. `ReLU` unsuitable (2nd derivative ≡ 0). |
 | Small network sizes | **Present** | PINNs are typically small MLPs; TinyMind targets embedded-scale models. |
 | Fixed-point / int8 inference | **Present** | Q-format and int8 pipelines run a plain forward pass of `u(x, t)`. |
-| Residual-loss training (∂residual/∂weights) | **Not yet** | Composing input-derivative AD with weight gradients; see next steps. |
+| Residual-loss training (∂residual/∂weights) | **Present** (`cpp/pinn.hpp`, `cpp/multidual.hpp`) | `sgdStep` gets the exact loss gradient w.r.t. all weights in one forward pass via `MultiDual<V,N>`; `sgdStepReverse` does it in one backward pass via the `RevVar` tape. See item 11 below. |
 
 The takeaway: TinyMind now ships the correct **activation family**, the correct
-**size class**, *and* the input-space differentiation operator. The remaining
-work is the training loop, not the derivatives.
+**size class**, the input-space differentiation operator, *and* the residual-loss
+training loop built on top of them.
 
 ## 2. The missing piece: forward-mode / Taylor-mode autodiff
 
@@ -211,6 +211,9 @@ Done:
    to the heat equation with the exact-autodiff residual and finite-difference
    weight gradients; drives the PINN loss down ~370x and the solution L2 error
    to ~1% — all host-side, no device.
+   *(Superseded by item 11: the finite-difference weight gradients described here
+   were replaced by exact one-pass `MultiDual` gradients. This list is a
+   chronological record; read item 11 for the current mechanism.)*
 9. ✅ Elementary `Dual` math (`cpp/dualmath.hpp`): `exp`/`sin`/`cos`/`sqrt` with
    analytic derivatives + nested-recursion (SIREN fields, trig/exp source terms),
    and mixed partials (`d²u/dx dy`) via per-level seed directions.


### PR DESCRIPTION
`docs/examples/pinn_heat1d.md` claimed:

> Weight gradients during training come from finite differences over the exact-autodiff residual.

That is wrong. The example calls `tinymind::pinn::sgdStep`, which obtains the exact loss gradient with respect to all 49 weights **in one forward pass** via vector forward-mode (`MultiDual<V, N>`).

Evidence, all from the shipped example:

- `pinn_heat1d.cpp:300` — `lossVal = tinymind::pinn::sgdStep<NP>(p, vel, lr, momentum, loss);`
- `pinn_heat1d.cpp:135` — *"loss gradient w.r.t. ALL weights is obtained EXACTLY in one pass via MultiDual (vector forward-mode) inside tinymind::pinn::sgdStep -- no finite differences."*
- Running `--train` prints `MultiDual one-pass exact weight gradients`

`README.md` and `cpp/pinn.hpp` were already correct; only this page was wrong. Finite differences appear in the example **solely** as an independent reference for checking the *input* derivatives.

## Where the wrong claim came from

`docs/pinn-feasibility.md` carries a numbered list that is a **chronological record**, not a description of current state:

- **Item 6** describes an earlier training loop that genuinely did use finite-difference weight gradients
- **Item 11** supersedes it with the `MultiDual` trainer

Read out of order, item 6 reads as current — which is how it ended up copied into the example page. Item 6 now carries an explicit note pointing at item 11. I left the historical wording intact rather than rewriting history.

## A second, live contradiction on the same page

The requirements table listed residual-loss training as **"Not yet"**, while items 11 and 13 further down mark both the forward-mode (`sgdStep`) and reverse-mode (`sgdStepReverse`) trainers complete, and the verdict paragraph still said "the remaining work is the training loop, not the derivatives". Table row and verdict both corrected.

## Measured figures added

The example page now carries numbers rather than pointing at a run. All reproduced by running the example:

**`make run`** — closed-form residual 0.000e+00 · `u_x` 9.207e-11 · `u_t` 3.753e-11 · `u_xx` 3.263e-06 (finite-difference round-off ~eps/h², not autodiff error) · Q16.16 vs float 1.655e-03

**`make train`** (8000 epochs, `PinnMlp 2->12->1`, 49 params) — residual loss 4.3726e+00 → 2.0989e-02 (208x) · solution L2 4.7870e-01 → 1.2615e-02 · fixed-point residual within 8.776e-03 of double

Docs only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
