### PR TITLE
ci: bound every apt call so a hung mirror retries instead of blocking

### DIFF
--- a/.github/actions/apt-install/action.yml
+++ b/.github/actions/apt-install/action.yml
@@ -1,9 +1,11 @@
 name: apt-install
 description: >
-  apt-get update + install with retries. GitHub-hosted runners intermittently
-  hit transient apt mirror/network failures (exit 100) at the install step,
-  which fail an otherwise-green job and send a false-alarm failure email. This
-  retries update+install a few times with linear backoff before giving up.
+  apt-get update + install with timeouts and retries. GitHub-hosted runners
+  intermittently hit transient apt mirror/network trouble, which shows up two
+  different ways: apt exits non-zero (exit 100), or apt HANGS on a stalled
+  connection and never returns. Retrying alone only covers the first. Every
+  apt call here is therefore bounded by both apt's own network timeouts and an
+  outer `timeout`, so a hang degrades into a failure the retry loop can absorb.
 
 inputs:
   packages:
@@ -12,7 +14,20 @@ inputs:
   attempts:
     description: Maximum number of attempts before failing.
     required: false
-    default: "5"
+    default: "4"
+  update-timeout:
+    description: Seconds to allow for a single apt-get update.
+    required: false
+    default: "120"
+  install-timeout:
+    description: >
+      Seconds to allow for a single apt-get install. The default is generous
+      next to a healthy runner (the largest package set in this repo,
+      gcc-arm-none-eabi, normally lands in well under a minute) so that a
+      merely slow mirror still succeeds and only a genuinely stuck one is cut
+      off.
+    required: false
+    default: "300"
 
 runs:
   using: composite
@@ -22,17 +37,50 @@ runs:
         set -uo pipefail
         packages="${{ inputs.packages }}"
         max="${{ inputs.attempts }}"
+        update_timeout="${{ inputs.update-timeout }}"
+        install_timeout="${{ inputs.install-timeout }}"
+
+        # Bound apt's own network waits so a stalled socket fails fast rather
+        # than blocking until the job's global timeout. The outer `timeout`
+        # below is the backstop for anything these do not cover (a wedged
+        # dpkg, a hung post-install script).
+        apt_opts="-o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
+        apt_opts="$apt_opts -o Acquire::ftp::Timeout=30 -o Acquire::Retries=2"
+
         for attempt in $(seq 1 "$max"); do
-          if sudo apt-get update && sudo apt-get install -y $packages; then
+          # Capture the status via `|| status=$?` rather than reading $? after
+          # an `if`: an `if` whose condition fails and which has no `else`
+          # branch itself returns 0, so `status=$?` there would always read
+          # success and every diagnostic would claim "exit 0".
+          #
+          # -k sends SIGKILL if the process ignores SIGTERM, so a wedged apt
+          # cannot outlive its budget.
+          status=0
+          sudo timeout -k 30 "$update_timeout" apt-get $apt_opts update &&
+            sudo timeout -k 30 "$install_timeout" apt-get $apt_opts install -y $packages ||
+            status=$?
+
+          if [ "$status" -eq 0 ]; then
             echo "apt-install: '$packages' succeeded on attempt $attempt"
             exit 0
           fi
+
+          if [ "$status" -eq 124 ] || [ "$status" -eq 137 ]; then
+            echo "apt-install: attempt $attempt/$max TIMED OUT (exit $status)" >&2
+          else
+            echo "apt-install: attempt $attempt/$max failed (exit $status)" >&2
+          fi
+
           if [ "$attempt" -lt "$max" ]; then
             wait=$((attempt * 10))
-            echo "apt-install: attempt $attempt/$max failed; cleaning and retrying in ${wait}s" >&2
+            echo "apt-install: cleaning and retrying in ${wait}s" >&2
+            # A killed apt can leave dpkg mid-transaction and the lock held;
+            # recover before the next attempt instead of failing on the lock.
+            sudo dpkg --configure -a || true
             sudo apt-get clean || true
             sleep "$wait"
           fi
         done
+
         echo "apt-install: '$packages' failed after $max attempts" >&2
         exit 1


### PR DESCRIPTION
The retry logic added in #155 covers apt **failing** (exit 100) but not apt **hanging**. A stalled mirror connection leaves `apt-get` blocked with no exit status, so the retry loop never runs and the job sits until the workflow's global timeout. The retry is effectively dead code in exactly the failure mode we keep hitting.

## Not hypothetical

Three consecutive runs of #165 hung on this:

| job | step | normal | observed |
|---|---|---|---|
| ARM cross-compile (Cortex-M) | Install arm-none-eabi toolchain | ~30s | **100 min**, then 31 min, then 21 min |
| Fuzz int8 kernels | Install Clang | ~35s | same pattern (recovered on attempt 3) |

Every job that installs nothing passed. `gcc-arm-none-eabi` is the largest package set in the matrix and was the most persistent casualty. GitHub's status page reported Actions "operational" throughout.

## The fix

Every apt call is now bounded **twice**:

- **apt's own `Acquire::*::Timeout=30`** with two internal retries — makes a stalled socket fail rather than block. This is the surgical part.
- **An outer `timeout -k 30`** as backstop for anything those don't cover: a wedged dpkg, a hung post-install script.

Timeouts are generous next to a healthy runner (120s update, 300s install) so a merely *slow* mirror still succeeds and only a genuinely stuck one is cut off. Default attempts drops 5 → 4 to keep the worst case near half an hour rather than an hour.

Cleanup between attempts now also runs `dpkg --configure -a`, because an apt killed mid-transaction leaves dpkg half-configured and the lock held — which would fail every *subsequent* attempt on the lock rather than retrying the download.

## Two details worth recording

**A bug my own first draft had.** Status is captured with `|| status=$?` rather than by reading `$?` after an `if`. An `if` whose condition fails and which has no `else` returns 0 *itself*, so the obvious shape reports `exit 0` for every failure. Local testing caught it — the draft printed `failed (exit 0)` on a timeout it had correctly detected and bounded.

**Timeouts are labelled.** Exit 124/137 are called out as `TIMED OUT` in the log, so "stuck mirror" versus "package genuinely missing" is visible without opening the run.

## Verification

Logic tested locally against stubbed apt in four modes:

| mode | result |
|---|---|
| hang | bounded (6s across 3 attempts, not 90s), reported as `TIMEOUT exit=124` |
| immediate failure | reported as `failed exit=100`, retried |
| immediate success | succeeds attempt 1 |
| fail-then-succeed | succeeds attempt 3 |

Extracted shell body passes `bash -n`; action YAML parses.

Applies to all **13 call sites** across the analysis workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
